### PR TITLE
Switch debug output from dbg!() to log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sntpc"
-version = "0.1.1"
+version = "0.1.2"
 description = "Library for making SNTP requests"
 homepage = "https://github.com/vpetrigo/sntpc"
 repository = "https://github.com/vpetrigo/sntpc"
@@ -12,7 +12,10 @@ authors = ["Vladimir Petrigo <taenaru@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+log = "0.4"
+
+[dev-dependencies]
+simple_logger = "1.3"
 
 [badges]
-
 travis-ci = { repository = "vpetrigo/sntpc", branch = "master" }

--- a/examples/simple_request.rs
+++ b/examples/simple_request.rs
@@ -1,3 +1,5 @@
+use log;
+use simple_logger;
 use sntpc;
 use std::{thread, time};
 
@@ -7,6 +9,12 @@ const POOL_NTP_ADDR: &str = "pool.ntp.org";
 const GOOGLE_NTP_ADDR: &str = "time.google.com";
 
 fn main() {
+    if cfg!(debug_assertions) {
+        simple_logger::init_with_level(log::Level::Trace).unwrap();
+    } else {
+        simple_logger::init_with_level(log::Level::Info).unwrap();
+    }
+
     for _ in 0..4000 {
         let result = sntpc::request(POOL_NTP_ADDR, 123);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 //! }
 //! ```
 
+use log::debug;
 use std::io;
 use std::mem;
 use std::net;
@@ -177,7 +178,7 @@ impl From<&NtpPacket> for RawNtpPacket {
 /// // .. process the result
 /// ```
 pub fn request(pool: &str, port: u32) -> io::Result<u32> {
-    dbg!(pool);
+    debug!("Pool: {}", pool);
     let socket = net::UdpSocket::bind("0.0.0.0:0")
         .expect("Unable to create a UDP socket");
     let dest = format!("{}:{}", pool, port).to_socket_addrs()?;
@@ -189,7 +190,7 @@ pub fn request(pool: &str, port: u32) -> io::Result<u32> {
     let mut success = false;
 
     for addr in dest {
-        dbg!(&addr);
+        debug!("Address: {}", &addr);
 
         match send_request(&req, &socket, addr) {
             Ok(write_bytes) => {
@@ -214,7 +215,7 @@ pub fn request(pool: &str, port: u32) -> io::Result<u32> {
 
     let mut buf: RawNtpPacket = RawNtpPacket::default();
     let response = socket.recv_from(buf.0.as_mut())?;
-    dbg!(response.0);
+    debug!("Response: {}", response.0);
 
     if response.0 == mem::size_of::<NtpPacket>() {
         let result = process_response(buf);
@@ -297,21 +298,21 @@ fn debug_ntp_packet(packet: &NtpPacket) {
     let version = shifter(packet.li_vn_mode, VERSION_MASK, VERSION_SHIFT);
     let li = shifter(packet.li_vn_mode, LI_MASK, LI_SHIFT);
 
-    println!("{}", (0..52).map(|_| "=").collect::<String>());
-    println!("| Mode:\t\t{}", mode);
-    println!("| Version:\t{}", version);
-    println!("| Leap:\t\t{}", li);
-    println!("| Poll:\t\t{}", packet.poll);
-    println!("| Precision:\t\t{}", packet.precision);
-    println!("| Root delay:\t\t{}", packet.root_delay);
-    println!("| Root dispersion:\t{}", packet.root_dispersion);
-    println!(
+    debug!("{}", (0..52).map(|_| "=").collect::<String>());
+    debug!("| Mode:\t\t{}", mode);
+    debug!("| Version:\t{}", version);
+    debug!("| Leap:\t\t{}", li);
+    debug!("| Poll:\t\t{}", packet.poll);
+    debug!("| Precision:\t\t{}", packet.precision);
+    debug!("| Root delay:\t\t{}", packet.root_delay);
+    debug!("| Root dispersion:\t{}", packet.root_dispersion);
+    debug!(
         "| Reference ID:\t\t{}",
         str::from_utf8(&packet.ref_id.to_be_bytes()).unwrap_or("")
     );
-    println!("| Reference timestamp:\t{:>16}", packet.ref_timestamp);
-    println!("| Origin timestamp:\t\t{:>16}", packet.origin_timestamp);
-    println!("| Receive timestamp:\t{:>16}", packet.recv_timestamp);
-    println!("| Transmit timestamp:\t{:>16}", packet.tx_timestamp);
-    println!("{}", (0..52).map(|_| "=").collect::<String>());
+    debug!("| Reference timestamp:\t{:>16}", packet.ref_timestamp);
+    debug!("| Origin timestamp:\t\t{:>16}", packet.origin_timestamp);
+    debug!("| Receive timestamp:\t\t{:>16}", packet.recv_timestamp);
+    debug!("| Transmit timestamp:\t\t{:>16}", packet.tx_timestamp);
+    debug!("{}", (0..52).map(|_| "=").collect::<String>());
 }


### PR DESCRIPTION
Update:
- `sntp` library to use `log` crate for DEBUG output
- `simple_requests` with `simple_logger` crate