### PR TITLE
Fix possible overflow in offset calculation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1018,9 +1018,7 @@ fn roundtrip_calculate(
 }
 
 fn offset_calculate(t1: u64, t2: u64, t3: u64, t4: u64, units: Units) -> i64 {
-    let theta = ((t2.wrapping_sub(t1) as i64) + (t3.wrapping_sub(t4) as i64))
-        as i64
-        / 2;
+    let theta = (t2.wrapping_sub(t1) as i64).wrapping_add(t3.wrapping_sub(t4) as i64) / 2;
     let theta_sec = (theta.abs() as u64 & SECONDS_MASK) >> 32;
     let theta_sec_fraction = theta.abs() as u64 & SECONDS_FRAC_MASK;
 


### PR DESCRIPTION
I'm running this on embedded hardware and if the current system time is 0, get_time() results in an overflow. This change adjusts the math to use an wrapping add to avoid the overflow.