### PR TITLE
docs: ✏️ typo, remove useless `examples`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ general idea on how to bootstrap `no_std` networking and timestamping tools for 
 -------------------
 
 Feature `async_tokio` allows to use crate together with [tokio](https://docs.rs/tokio/latest/tokio/).
-There is an example: [`examples/tokio.rs`](examples/examples/tokio.rs).
+There is an example: [`examples/tokio.rs`](examples/tokio.rs).
 
 There is also `no_std` support with feature `async`, but it requires Rust >= `1.75-nightly` version.
 The example can be found in [separate repository](https://github.com/vpikulik/sntpc_embassy).


### PR DESCRIPTION
`examples/examples/tokio.rs` is 404.

Fix it with `examples/tokio.rs`.