### PR TITLE
RFC: Add embassy net support

### DIFF
--- a/examples/simple-no-std/src/main.rs
+++ b/examples/simple-no-std/src/main.rs
@@ -5,7 +5,7 @@ use core::cell::UnsafeCell;
 use core::future::Future;
 use core::ptr::null_mut;
 use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
-use sntpc::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
+use sntpc::net::{IpAddr, Ipv4Addr, SocketAddr};
 use sntpc::{
     async_impl::{get_time, NtpUdpSocket},
     NtpContext, NtpTimestampGenerator, Result,
@@ -96,10 +96,10 @@ impl NtpTimestampGenerator for TimestampGen {
 struct SimpleUdp;
 
 impl NtpUdpSocket for SimpleUdp {
-    fn send_to<T: ToSocketAddrs + Send>(
+    fn send_to(
         &self,
         _buf: &[u8],
-        _addr: T,
+        _addr: SocketAddr,
     ) -> impl Future<Output = Result<usize>> {
         core::future::ready(Ok(48))
     }

--- a/examples/smoltcp-request/src/main.rs
+++ b/examples/smoltcp-request/src/main.rs
@@ -77,9 +77,12 @@
 //! $ 2021-11-08 23:53:29,950 INFO [smoltcp_request] Ok(NtpResult { seconds: 1636404809, seconds_fraction: 4004704152, roundtrip: 36149, offset: 927 })
 //! ```
 //!
+
+use std::net::ToSocketAddrs;
 #[cfg(unix)]
 use {
     core::cell::RefCell,
+    core::net::{IpAddr, SocketAddr},
     core::str::FromStr,
     smoltcp::iface::{Config, Interface, SocketSet},
     smoltcp::phy::TunTapInterface,
@@ -88,7 +91,6 @@ use {
     smoltcp::time::Instant,
     smoltcp::wire::{EthernetAddress, IpCidr, Ipv4Address},
     sntpc::NtpContext,
-    std::net::{IpAddr, SocketAddr},
     std::os::unix::prelude::AsRawFd,
 };
 
@@ -303,7 +305,11 @@ fn main() {
     let server_port = u16::from_str(app.value_of("port").unwrap())
         .expect("Unable to parse server port");
     let server_sock_addr =
-        SocketAddr::new(IpAddr::from_str(server_ip).unwrap(), server_port);
+        SocketAddr::new(IpAddr::from_str(server_ip).unwrap(), server_port)
+            .to_socket_addrs()
+            .expect("Cannot parse address")
+            .next()
+            .expect("Unable to resolve address");
     let eth_address = EthernetAddress::from_str(app.value_of("mac").unwrap())
         .expect("Cannot parse MAC address of the interface");
     let ip_addr = IpCidr::from_str(app.value_of("ip").unwrap())

--- a/examples/tokio/src/main.rs
+++ b/examples/tokio/src/main.rs
@@ -3,7 +3,7 @@ use sntpc::{
     Error, NtpContext, Result, StdTimestampGen,
 };
 use std::net::SocketAddr;
-use tokio::net::{ToSocketAddrs, UdpSocket};
+use tokio::net::UdpSocket;
 
 const POOL_NTP_ADDR: &str = "pool.ntp.org:123";
 
@@ -14,11 +14,7 @@ struct Socket {
 
 #[async_trait::async_trait]
 impl NtpUdpSocket for Socket {
-    async fn send_to<T: ToSocketAddrs + Send>(
-        &self,
-        buf: &[u8],
-        addr: T,
-    ) -> Result<usize> {
+    async fn send_to(&self, buf: &[u8], addr: SocketAddr) -> Result<usize> {
         self.sock
             .send_to(buf, addr)
             .await

--- a/sntpc/Cargo.toml
+++ b/sntpc/Cargo.toml
@@ -29,9 +29,6 @@ async_tokio = ["std", "async", "tokio", "async-trait"]
 [dependencies]
 log = { version = "~0.4", optional = true }
 chrono = { version = "~0.4", default-features = false, optional = true }
-# requred till this https://github.com/rust-lang/rfcs/pull/2832 is not addressed
-no-std-net = "~0.6"
-
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 

--- a/sntpc/Cargo.toml
+++ b/sntpc/Cargo.toml
@@ -25,12 +25,14 @@ std = []
 utils = ["std", "chrono/clock"]
 async = []
 async_tokio = ["std", "async", "tokio", "async-trait"]
+embassy = ["embassy-net", "async"]
 
 [dependencies]
 log = { version = "~0.4", optional = true }
 chrono = { version = "~0.4", default-features = false, optional = true }
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
+embassy-net = { version = "0.5.0", features = [ "udp", "proto-ipv4", "proto-ipv6", "medium-ip"], optional = true }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/sntpc/src/async_impl.rs
+++ b/sntpc/src/async_impl.rs
@@ -50,6 +50,7 @@ pub trait NtpUdpSocket {
     ) -> impl core::future::Future<Output = Result<(usize, SocketAddr)>>;
 }
 
+#[cfg(feature = "embassy")]
 impl NtpUdpSocket for &embassy_net::udp::UdpSocket<'_> {
     async fn send_to<T: ToSocketAddrs + Send>(
         &self,

--- a/sntpc/src/async_impl.rs
+++ b/sntpc/src/async_impl.rs
@@ -52,10 +52,10 @@ pub trait NtpUdpSocket {
 
 #[cfg(feature = "embassy")]
 impl NtpUdpSocket for &embassy_net::udp::UdpSocket<'_> {
-    async fn send_to<T: ToSocketAddrs + Send>(
+    async fn send_to(
         &self,
         buf: &[u8],
-        addr: T,
+        addr: SocketAddr,
     ) -> Result<usize> {
         let saddr: SocketAddr = addr
             .to_socket_addrs()
@@ -115,13 +115,12 @@ impl NtpUdpSocket for &embassy_net::udp::UdpSocket<'_> {
 /// # Errors
 ///
 /// Will return `Err` if an SNTP request sending fails
-pub async fn sntp_send_request<A, U, T>(
-    dest: A,
+pub async fn sntp_send_request<U, T>(
+    dest: SocketAddr,
     socket: &U,
     context: NtpContext<T>,
 ) -> Result<SendRequestResult>
 where
-    A: ToSocketAddrs + Debug + Send,
     U: NtpUdpSocket,
     T: NtpTimestampGenerator + Copy,
 {
@@ -133,8 +132,8 @@ where
     Ok(SendRequestResult::from(request))
 }
 
-async fn send_request<A: ToSocketAddrs + Send, U: NtpUdpSocket>(
-    dest: A,
+async fn send_request< U: NtpUdpSocket>(
+    dest: SocketAddr,
     req: &NtpPacket,
     socket: &U,
 ) -> core::result::Result<(), Error> {
@@ -158,14 +157,13 @@ async fn send_request<A: ToSocketAddrs + Send, U: NtpUdpSocket>(
 /// # Errors
 ///
 /// Will return `Err` if an SNTP response processing fails
-pub async fn sntp_process_response<A, U, T>(
-    dest: A,
+pub async fn sntp_process_response<U, T>(
+    dest: SocketAddr,
     socket: &U,
     mut context: NtpContext<T>,
     send_req_result: SendRequestResult,
 ) -> Result<NtpResult>
 where
-    A: ToSocketAddrs + Debug,
     U: NtpUdpSocket,
     T: NtpTimestampGenerator + Copy,
 {
@@ -203,13 +201,12 @@ where
 /// # Errors
 ///
 /// Will return `Err` if an SNTP request cannot be sent or SNTP response fails
-pub async fn get_time<A, U, T>(
-    pool_addrs: A,
+pub async fn get_time< U, T>(
+    pool_addrs: SocketAddr,
     socket: U,
     context: NtpContext<T>,
 ) -> Result<NtpResult>
 where
-    A: ToSocketAddrs + Copy + Debug + Send,
     U: NtpUdpSocket,
     T: NtpTimestampGenerator + Copy,
 {

--- a/sntpc/src/types.rs
+++ b/sntpc/src/types.rs
@@ -304,17 +304,10 @@ pub trait NtpUdpSocket {
     /// Send the given buffer to an address provided. On success, returns the number
     /// of bytes written.
     ///
-    /// Since multiple `SocketAddr` objects can hide behind the type (domain name can be
-    /// resolved to multiple addresses), the method should send data to a single address
-    /// available in `addr`
     /// # Errors
     ///
     /// Will return `Err` if an underlying UDP send fails
-    fn send_to<T: net::ToSocketAddrs>(
-        &self,
-        buf: &[u8],
-        addr: T,
-    ) -> Result<usize>;
+    fn send_to(&self, buf: &[u8], addr: net::SocketAddr) -> Result<usize>;
 
     /// Receives a single datagram message on the socket. On success, returns the number
     /// of bytes read and the origin.
@@ -329,10 +322,10 @@ pub trait NtpUdpSocket {
 
 #[cfg(feature = "std")]
 impl NtpUdpSocket for net::UdpSocket {
-    fn send_to<T: net::ToSocketAddrs>(
+    fn send_to(
         &self,
         buf: &[u8],
-        addr: T,
+        addr: net::SocketAddr,
     ) -> core::result::Result<usize, Error> {
         match self.send_to(buf, addr) {
             Ok(usize) => Ok(usize),


### PR DESCRIPTION
This is a little something I cooked up for little embassy based esp32 project.
Using these changes I was able to get times from a timeserver.

embassy-net switched to core::net addresses recently, however, smoltcp (which is used under the hood) didn't switch completely, hence some type conversion is still needed.

What do you think? Would you consider supporting embassy-net in this crate?