### PR TITLE
Use core::net::SocketAddr for the NtpUdpSocket interface 

### DIFF
--- a/examples/simple-no-std/src/main.rs
+++ b/examples/simple-no-std/src/main.rs
@@ -5,7 +5,7 @@ use core::cell::UnsafeCell;
 use core::future::Future;
 use core::ptr::null_mut;
 use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
-use sntpc::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
+use sntpc::net::{IpAddr, Ipv4Addr, SocketAddr};
 use sntpc::{
     async_impl::{get_time, NtpUdpSocket},
     NtpContext, NtpTimestampGenerator, Result,
@@ -96,10 +96,10 @@ impl NtpTimestampGenerator for TimestampGen {
 struct SimpleUdp;
 
 impl NtpUdpSocket for SimpleUdp {
-    fn send_to<T: ToSocketAddrs + Send>(
+    fn send_to(
         &self,
         _buf: &[u8],
-        _addr: T,
+        _addr: SocketAddr,
     ) -> impl Future<Output = Result<usize>> {
         core::future::ready(Ok(48))
     }

--- a/examples/tokio/src/main.rs
+++ b/examples/tokio/src/main.rs
@@ -3,7 +3,7 @@ use sntpc::{
     Error, NtpContext, Result, StdTimestampGen,
 };
 use std::net::SocketAddr;
-use tokio::net::{ToSocketAddrs, UdpSocket};
+use tokio::net::UdpSocket;
 
 const POOL_NTP_ADDR: &str = "pool.ntp.org:123";
 
@@ -14,11 +14,7 @@ struct Socket {
 
 #[async_trait::async_trait]
 impl NtpUdpSocket for Socket {
-    async fn send_to<T: ToSocketAddrs + Send>(
-        &self,
-        buf: &[u8],
-        addr: T,
-    ) -> Result<usize> {
+    async fn send_to(&self, buf: &[u8], addr: SocketAddr) -> Result<usize> {
         self.sock
             .send_to(buf, addr)
             .await

--- a/sntpc/Cargo.toml
+++ b/sntpc/Cargo.toml
@@ -25,12 +25,14 @@ std = []
 utils = ["std", "chrono/clock"]
 async = []
 async_tokio = ["std", "async", "tokio", "async-trait"]
+defmt = ["dep:defmt"]
 
 [dependencies]
 log = { version = "~0.4", optional = true }
 chrono = { version = "~0.4", default-features = false, optional = true }
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
+defmt = { version = "0.3", optional = true }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/sntpc/Cargo.toml
+++ b/sntpc/Cargo.toml
@@ -29,9 +29,6 @@ async_tokio = ["std", "async", "tokio", "async-trait"]
 [dependencies]
 log = { version = "~0.4", optional = true }
 chrono = { version = "~0.4", default-features = false, optional = true }
-# requred till this https://github.com/rust-lang/rfcs/pull/2832 is not addressed
-no-std-net = "~0.6"
-
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 

--- a/sntpc/src/types.rs
+++ b/sntpc/src/types.rs
@@ -94,6 +94,7 @@ impl Display for Units {
 /// The error type for SNTP client
 /// Errors originate on network layer or during processing response from a NTP server
 #[derive(Debug, PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {
     /// Origin timestamp value in a NTP response differs from the value

--- a/sntpc/src/types.rs
+++ b/sntpc/src/types.rs
@@ -304,17 +304,10 @@ pub trait NtpUdpSocket {
     /// Send the given buffer to an address provided. On success, returns the number
     /// of bytes written.
     ///
-    /// Since multiple `SocketAddr` objects can hide behind the type (domain name can be
-    /// resolved to multiple addresses), the method should send data to a single address
-    /// available in `addr`
     /// # Errors
     ///
     /// Will return `Err` if an underlying UDP send fails
-    fn send_to<T: net::ToSocketAddrs>(
-        &self,
-        buf: &[u8],
-        addr: T,
-    ) -> Result<usize>;
+    fn send_to(&self, buf: &[u8], addr: net::SocketAddr) -> Result<usize>;
 
     /// Receives a single datagram message on the socket. On success, returns the number
     /// of bytes read and the origin.
@@ -329,10 +322,10 @@ pub trait NtpUdpSocket {
 
 #[cfg(feature = "std")]
 impl NtpUdpSocket for net::UdpSocket {
-    fn send_to<T: net::ToSocketAddrs>(
+    fn send_to(
         &self,
         buf: &[u8],
-        addr: T,
+        addr: net::SocketAddr,
     ) -> core::result::Result<usize, Error> {
         match self.send_to(buf, addr) {
             Ok(usize) => Ok(usize),


### PR DESCRIPTION
Now that it is available, to make it easier to integrate with various network implementations such as embassy-net.