### PR TITLE
fix: core::net build and add an embassy-net example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run clippy with all features
-        run: cargo clippy --workspace --exclude example-simple-no-std --all-features -- -D clippy::all -D clippy::pedantic
-      - name: Run clippy with no_std
-        run: cargo clippy -p example-simple-no-std --no-default-features --profile no-std -- -D clippy::all -D clippy::pedantic
+        run: cargo clippy --workspace --exclude example-simple-no-std --exclude example-smoltcp-request --exclude example-embassy-net --all-features -- -D clippy::all -D clippy::pedantic
+      - name: Run clippy on examples
+        run: |
+          cargo clippy -p example-simple-no-std --no-default-features --profile no-std -- -D clippy::all -D clippy::pedantic
+          cargo clippy -p example-smoltcp-request --all-features -- -D clippy::all -D clippy::pedantic
+          cargo clippy -p example-embassy-net --all-features -- -D clippy::all -D clippy::pedantic
   clippy_async_no_std:
     runs-on: ubuntu-latest
     container:
@@ -40,11 +43,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build with std
-        run: cargo build --workspace --exclude example-simple-no-std --all-features
+        run: cargo build --workspace --exclude example-simple-no-std --exclude example-smoltcp-request --exclude example-embassy-net --all-features
       - name: Build with no_std
+        run: cargo build -p sntpc --no-default-features
+      - name: Build examples
         run: |
-          cargo build -p sntpc --no-default-features
           cargo build -p example-simple-no-std --profile no-std
+          cargo build -p example-smoltcp-request --all-features
+          cargo build -p example-embassy-net --all-features
       - name: Run tests with std
         run: cargo test
       - name: Run tests with no_std

--- a/examples/embassy-net/Cargo.toml
+++ b/examples/embassy-net/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "example-embassy-net"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[features]
+log = ["dep:simple_logger", "dep:log", "sntpc/log", "embassy-executor/log", "embassy-time/log", "embassy-net/log"]
+
+[dependencies]
+sntpc = { path = "../../sntpc", default-features = false, features = ["embassy"] }
+log = { version = "~0.4", optional = true }
+simple_logger = { version = "~1.13", optional = true }
+embassy-executor = { version = "0.6.3", features = ["task-arena-size-32768", "arch-std", "executor-thread"] }
+embassy-time = { version = "0.3.2", features = ["std", "generic-queue" ] }
+embassy-net = { version = "0.5.0", features=["std", "medium-ethernet", "medium-ip", "tcp", "udp", "dns", "dhcpv4", "proto-ipv6"] }
+embassy-net-tuntap = "0.1.0"
+static_cell = "2"
+embedded-io-async = "0.6.1"
+heapless = { version = "0.8", default-features = false }

--- a/examples/embassy-net/src/main.rs
+++ b/examples/embassy-net/src/main.rs
@@ -1,0 +1,159 @@
+//! Demonstrates how to use [`embassy-net`] with the [`sntpc`] library.
+//!
+//! This example fetches the current time from a NTP server using the
+//! SNTP client library and prints the result.
+//!
+//! ## Create a TUN/TAP interface
+//!
+//! ```sh
+//! sudo ip tuntap add name tap0 mode tap
+//! sudo ip link set tap0 up
+//! sudo ip addr add 192.168.69.1/24 dev tap0
+//!
+//! # Enable IP forwarding
+//! sudo sysctl -w net.ipv4.ip_forward=1
+//!
+//! # Enable NAT for the tap0 interface
+//! export DEFAULT_IFACE=$(ip route show default | grep -oP 'dev \K\S+')
+//! sudo iptables -A FORWARD -i tap0 -j ACCEPT
+//! sudo iptables -A FORWARD -o ${DEFAULT_IFACE} -j ACCEPT
+//! sudo iptables -t nat -A POSTROUTING -o ${DEFAULT_IFACE} -j MASQUERADE
+//! ```
+//!
+//! ## Run the example
+//!
+//! ```sh
+//! cargo build --features "log"
+//! sudo ../../target/debug/example-embassy-net
+//! ```
+//!
+//! ## Cleanup
+//!
+//! To remove the TUN/TAP interface, run:
+//!
+//! ```sh
+//! sudo ip link del tap0
+//! ```
+
+use embassy_executor::{Executor, Spawner};
+use embassy_net::dns::DnsQueryType;
+use embassy_net::udp::{PacketMetadata, UdpSocket};
+use embassy_net::{Config, IpEndpoint, Ipv4Address, Ipv4Cidr, StackResources};
+use embassy_net_tuntap::TunTapDevice;
+use embassy_time::{Duration, Timer};
+use heapless::Vec;
+use sntpc::{async_impl::get_time, NtpContext, NtpTimestampGenerator};
+use static_cell::StaticCell;
+
+#[cfg(feature = "log")]
+use log::{error, info};
+
+#[embassy_executor::task]
+async fn net_task(mut runner: embassy_net::Runner<'static, TunTapDevice>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn main_task(spawner: Spawner) {
+    static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+
+    // Create TUN/TAP device
+    let device = TunTapDevice::new("tap0").unwrap();
+
+    // Configure network stack
+    let config = Config::ipv4_static(embassy_net::StaticConfigV4 {
+        address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 69, 2), 24),
+        dns_servers: Vec::from_slice(&[Ipv4Address::new(8, 8, 8, 8)]).unwrap(),
+        gateway: Some(Ipv4Address::new(192, 168, 69, 1)),
+    });
+
+    // Init network stack
+    let (stack, runner) = embassy_net::new(
+        device,
+        config,
+        RESOURCES.init(StackResources::new()),
+        0,
+    );
+
+    // Launch network task
+    spawner.spawn(net_task(runner)).unwrap();
+
+    // Wait for the tap interface to be up before continuing
+    stack.wait_config_up().await;
+
+    // Create UDP socket
+    let mut rx_meta = [PacketMetadata::EMPTY; 16];
+    let mut rx_buffer = [0; 4096];
+    let mut tx_meta = [PacketMetadata::EMPTY; 16];
+    let mut tx_buffer = [0; 4096];
+
+    let mut socket = UdpSocket::new(
+        stack,
+        &mut rx_meta,
+        &mut rx_buffer,
+        &mut tx_meta,
+        &mut tx_buffer,
+    );
+    socket.bind(123).unwrap();
+
+    let context = NtpContext::new(StdTimestampGen::default());
+
+    let ntp_addrs = stack
+        .dns_query("pool.ntp.org", DnsQueryType::A)
+        .await
+        .expect("Failed to resolve DNS");
+    if ntp_addrs.is_empty() {
+        #[cfg(feature = "log")]
+        error!("Failed to resolve DNS");
+        return;
+    }
+
+    loop {
+        let result =
+            get_time(IpEndpoint::new(ntp_addrs[0], 123), &socket, context)
+                .await
+                .unwrap();
+
+        #[cfg(feature = "log")]
+        info!("Time: {:?}", result);
+
+        Timer::after(Duration::from_secs(15)).await;
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+fn main() {
+    #[cfg(feature = "log")]
+    if cfg!(debug_assertions) {
+        simple_logger::init_with_level(log::Level::Trace).unwrap();
+    } else {
+        simple_logger::init_with_level(log::Level::Info).unwrap();
+    }
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(main_task(spawner)).unwrap();
+    });
+}
+
+#[derive(Copy, Clone, Default)]
+struct StdTimestampGen {
+    duration: std::time::Duration,
+}
+
+impl NtpTimestampGenerator for StdTimestampGen {
+    fn init(&mut self) {
+        self.duration = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap();
+    }
+
+    fn timestamp_sec(&self) -> u64 {
+        self.duration.as_secs()
+    }
+
+    fn timestamp_subsec_micros(&self) -> u32 {
+        self.duration.subsec_micros()
+    }
+}

--- a/examples/simple-no-std/src/main.rs
+++ b/examples/simple-no-std/src/main.rs
@@ -119,7 +119,8 @@ async fn body() -> Result<i32> {
     let timestamp_gen = TimestampGen::default();
     let context = NtpContext::new(timestamp_gen);
     let socket = SimpleUdp;
-    let address = (IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 123u16);
+    let address =
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 123u16);
 
     match get_time(address, socket, context).await {
         Ok(time) => {

--- a/examples/simple-request/src/main.rs
+++ b/examples/simple-request/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
 
     for _ in 0..5 {
         let socket =
-            UdpSocket::bind("0.0.0.0:0").expect("Unable to crate UDP socket");
+            UdpSocket::bind("0.0.0.0:0").expect("Unable to create UDP socket");
         socket
             .set_read_timeout(Some(Duration::from_secs(2)))
             .expect("Unable to set UDP socket read timeout");

--- a/examples/smoltcp-request/src/main.rs
+++ b/examples/smoltcp-request/src/main.rs
@@ -170,7 +170,7 @@ pub mod internal {
         pub socket: RefCell<&'b mut udp::Socket<'a>>,
     }
 
-    impl<'a, 'b> Debug for SmoltcpUdpSocketWrapper<'a, 'b> {
+    impl Debug for SmoltcpUdpSocketWrapper<'_, '_> {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             f.debug_struct("SmoltcpUdpSocketWrapper")
                 .field("socket", &self.socket.borrow().endpoint())
@@ -178,7 +178,7 @@ pub mod internal {
         }
     }
 
-    impl<'a, 'b> NtpUdpSocket for SmoltcpUdpSocketWrapper<'a, 'b> {
+    impl NtpUdpSocket for SmoltcpUdpSocketWrapper<'_, '_> {
         fn send_to(
             &self,
             buf: &[u8],

--- a/examples/smoltcp-request/src/main.rs
+++ b/examples/smoltcp-request/src/main.rs
@@ -290,6 +290,7 @@ use internal::{
 };
 
 #[cfg(unix)]
+#[allow(clippy::too_many_lines)]
 fn main() {
     #[cfg(feature = "log")]
     if cfg!(feature = "log") {

--- a/examples/tokio/Cargo.toml
+++ b/examples/tokio/Cargo.toml
@@ -7,4 +7,3 @@ publish = false
 [dependencies]
 sntpc = { path = "../../sntpc", default-features = false, features = ["async_tokio"] }
 tokio = { version = "1", features = ["full"] }
-async-trait = { version = "0.1" }

--- a/examples/tokio/src/main.rs
+++ b/examples/tokio/src/main.rs
@@ -1,37 +1,14 @@
-use sntpc::{
-    async_impl::{get_time, NtpUdpSocket},
-    Error, NtpContext, Result, StdTimestampGen,
-};
+use sntpc::{async_impl::get_time, NtpContext, StdTimestampGen};
 use std::net::SocketAddr;
 use tokio::net::UdpSocket;
 
 const POOL_NTP_ADDR: &str = "pool.ntp.org:123";
 
-#[derive(Debug)]
-struct Socket {
-    sock: UdpSocket,
-}
-
-#[async_trait::async_trait]
-impl NtpUdpSocket for Socket {
-    async fn send_to(&self, buf: &[u8], addr: SocketAddr) -> Result<usize> {
-        self.sock
-            .send_to(buf, addr)
-            .await
-            .map_err(|_| Error::Network)
-    }
-
-    async fn recv_from(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
-        self.sock.recv_from(buf).await.map_err(|_| Error::Network)
-    }
-}
-
 #[tokio::main]
 async fn main() {
-    let sock = UdpSocket::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap())
+    let socket = UdpSocket::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap())
         .await
         .expect("Socket creation");
-    let socket = Socket { sock };
     let ntp_context = NtpContext::new(StdTimestampGen::default());
 
     let res = get_time(POOL_NTP_ADDR, socket, ntp_context)

--- a/sntpc/Cargo.toml
+++ b/sntpc/Cargo.toml
@@ -24,13 +24,12 @@ default = ["std"]
 std = []
 utils = ["std", "chrono/clock"]
 async = []
-async_tokio = ["std", "async", "tokio", "async-trait"]
+async_tokio = ["std", "async", "tokio"]
 embassy = ["embassy-net", "async"]
 
 [dependencies]
 log = { version = "~0.4", optional = true }
 chrono = { version = "~0.4", default-features = false, optional = true }
-async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 embassy-net = { version = "0.5.0", features = [ "udp", "proto-ipv4", "proto-ipv6", "medium-ip"], optional = true }
 

--- a/sntpc/src/lib.rs
+++ b/sntpc/src/lib.rs
@@ -221,7 +221,7 @@ pub mod net {
             }
         }
 
-        impl<'a, T: ToSocketAddrs + ?Sized> ToSocketAddrs for &'a T {
+        impl<T: ToSocketAddrs + ?Sized> ToSocketAddrs for &T {
             type Iter = T::Iter;
             fn to_socket_addrs(&self) -> Result<T::Iter, ToSocketAddrError> {
                 (**self).to_socket_addrs()

--- a/sntpc/src/lib.rs
+++ b/sntpc/src/lib.rs
@@ -245,25 +245,6 @@ pub mod net {
                 .into_iter())
             }
         }
-
-        #[cfg(feature = "embassy")]
-        impl ToSocketAddrs for (embassy_net::IpAddress, u16) {
-            type Iter = core::option::IntoIter<SocketAddr>;
-            fn to_socket_addrs(
-                &self,
-            ) -> Result<core::option::IntoIter<SocketAddr>, ToSocketAddrError>
-            {
-                let (ip, port) = *self;
-                match ip {
-                    embassy_net::IpAddress::Ipv4(a) => {
-                        (a, port).to_socket_addrs()
-                    }
-                    embassy_net::IpAddress::Ipv6(a) => {
-                        (a, port).to_socket_addrs()
-                    }
-                }
-            }
-        }
     }
 
     pub use core::net::{

--- a/sntpc/src/types.rs
+++ b/sntpc/src/types.rs
@@ -321,7 +321,7 @@ pub trait NtpUdpSocket {
 }
 
 #[cfg(feature = "std")]
-impl NtpUdpSocket for net::UdpSocket {
+impl NtpUdpSocket for std::net::UdpSocket {
     fn send_to(
         &self,
         buf: &[u8],


### PR DESCRIPTION
We have to rework the ci a bit due to the `smoltcp` and `embassy-net` examples conflicting with each other.

I've also moved in the tokio NtpUdpSocket implementation, like embassy. So that users don't have to implement the trait themselves.

I've also put together an `embassy-net` example that uses a tap interface in a similar fashion to the smoltcp example.

Also had to make a bunch of small fixes to get all the examples building and running.