### PR TITLE
examples: embassy: Add NTP example using `embassy-net` and `sntpc` li…

### DIFF
--- a/examples/embassy-net/Cargo.toml
+++ b/examples/embassy-net/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "example-embassy-net"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[features]
+log = ["dep:simple_logger", "dep:log", "sntpc/log", "embassy-executor/log", "embassy-time/log", "embassy-net/log"]
+
+[dependencies]
+sntpc = { path = "../../sntpc", default-features = false, features = ["embassy-socket"] }
+log = { version = "~0.4", optional = true }
+simple_logger = { version = "5", optional = true }
+embassy-executor = { version = "0.6.3", features = ["task-arena-size-32768", "arch-std", "executor-thread"] }
+embassy-time = { version = "0.3.2", features = ["std", "generic-queue"] }
+embassy-net = { version = "0.5.0", features = ["std", "medium-ethernet", "udp", "dns"] }
+static_cell = "2"
+heapless = { version = "0.8", default-features = false }
+
+[target.'cfg(unix)'.dependencies]
+embassy-net-tuntap = "0.1.0"

--- a/examples/embassy-net/src/main.rs
+++ b/examples/embassy-net/src/main.rs
@@ -1,0 +1,193 @@
+//! Demonstrates how to use [`embassy-net`] with the [`sntpc`] library.
+//!
+//! This example fetches the current time from a NTP server using the
+//! SNTP client library and prints the result.
+//!
+//! ## Create a TUN/TAP interface
+//!
+//! ```sh
+//! sudo ip tuntap add name tap0 mode tap
+//! sudo ip link set tap0 up
+//! sudo ip addr add 192.168.69.1/24 dev tap0
+//!
+//! # Enable IP forwarding
+//! sudo sysctl -w net.ipv4.ip_forward=1
+//!
+//! # Enable NAT for the tap0 interface
+//! export DEFAULT_IFACE=$(ip route show default | grep -oP 'dev \K\S+')
+//! sudo iptables -A FORWARD -i tap0 -j ACCEPT
+//! sudo iptables -A FORWARD -o ${DEFAULT_IFACE} -j ACCEPT
+//! sudo iptables -t nat -A POSTROUTING -o ${DEFAULT_IFACE} -j MASQUERADE
+//! ```
+//!
+//! ## Run the example
+//!
+//! ```sh
+//! cargo build --features "log"
+//! sudo ../../target/debug/example-embassy-net
+//! ```
+//!
+//! ## Cleanup
+//!
+//! To remove the TUN/TAP interface, run:
+//!
+//! ```sh
+//! sudo ip link del tap0
+//! ```
+macro_rules! cfg_unix {
+    ($($item:item)*) => {
+        $(
+            #[cfg(unix)]
+            $item
+        )*
+    };
+}
+
+macro_rules! cfg_win {
+    ($($item:item)*) => {
+        $(
+            #[cfg(windows)]
+            $item
+        )*
+    };
+}
+
+cfg_unix! {
+    use embassy_executor::{Executor, Spawner};
+    use embassy_net::dns::DnsQueryType;
+    use embassy_net::udp::{PacketMetadata, UdpSocket};
+    use embassy_net::{Config, Ipv4Address, Ipv4Cidr, StackResources};
+    use embassy_net_tuntap::TunTapDevice;
+    use embassy_time::{Duration, Timer};
+    use heapless::Vec;
+    use sntpc::{get_time, NtpContext, NtpTimestampGenerator};
+    use static_cell::StaticCell;
+
+    use core::net::{IpAddr, SocketAddr};
+    use std::time::SystemTime;
+    
+    const NTP_SERVER: &str = "pool.ntp.org";
+
+    #[derive(Copy, Clone, Default)]
+    struct Timestamp {
+        duration: std::time::Duration,
+    }
+
+    impl NtpTimestampGenerator for Timestamp {
+        fn init(&mut self) {
+            self.duration = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap();
+        }
+
+        fn timestamp_sec(&self) -> u64 {
+            self.duration.as_secs()
+        }
+
+        fn timestamp_subsec_micros(&self) -> u32 {
+            self.duration.subsec_micros()
+        }
+    }
+
+    #[cfg(feature = "log")]
+    use log::{error, info};
+
+    #[embassy_executor::task]
+    async fn net_task(
+        mut runner: embassy_net::Runner<'static, TunTapDevice>,
+    ) -> ! {
+        runner.run().await
+    }
+
+    #[embassy_executor::task]
+    async fn main_task(spawner: Spawner) {
+        static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+
+        // Create TUN/TAP device
+        let device = TunTapDevice::new("tap0").unwrap();
+
+        // Configure network stack
+        let config = Config::ipv4_static(embassy_net::StaticConfigV4 {
+            address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 69, 2), 24),
+            dns_servers: Vec::from_slice(&[Ipv4Address::new(8, 8, 8, 8)])
+                .unwrap(),
+            gateway: Some(Ipv4Address::new(192, 168, 69, 1)),
+        });
+
+        // Init network stack
+        let (stack, runner) = embassy_net::new(
+            device,
+            config,
+            RESOURCES.init(StackResources::new()),
+            0,
+        );
+
+        // Launch network task
+        spawner.spawn(net_task(runner)).unwrap();
+
+        // Wait for the tap interface to be up before continuing
+        stack.wait_config_up().await;
+
+        // Create UDP socket
+        let mut rx_meta = [PacketMetadata::EMPTY; 16];
+        let mut rx_buffer = [0; 4096];
+        let mut tx_meta = [PacketMetadata::EMPTY; 16];
+        let mut tx_buffer = [0; 4096];
+
+        let mut socket = UdpSocket::new(
+            stack,
+            &mut rx_meta,
+            &mut rx_buffer,
+            &mut tx_meta,
+            &mut tx_buffer,
+        );
+        socket.bind(123).unwrap();
+
+        let context = NtpContext::new(Timestamp::default());
+
+        let ntp_addrs = stack
+            .dns_query(NTP_SERVER, DnsQueryType::A)
+            .await
+            .expect("Failed to resolve DNS");
+        if ntp_addrs.is_empty() {
+            #[cfg(feature = "log")]
+            error!("Failed to resolve DNS");
+            return;
+        }
+
+        loop {
+            let addr: IpAddr = ntp_addrs[0].into();
+            let result =
+                get_time(SocketAddr::from((addr, 123)), &socket, context)
+                    .await
+                    .unwrap();
+
+            #[cfg(feature = "log")]
+            info!("Time: {:?}", result);
+
+            Timer::after(Duration::from_secs(15)).await;
+        }
+    }
+
+    static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+    fn main() {
+        #[cfg(feature = "log")]
+        if cfg!(debug_assertions) {
+            simple_logger::init_with_level(log::Level::Trace).unwrap();
+        } else {
+            simple_logger::init_with_level(log::Level::Info).unwrap();
+        }
+
+        let executor = EXECUTOR.init(Executor::new());
+        executor.run(|spawner| {
+            spawner.spawn(main_task(spawner)).unwrap();
+        });
+    }
+}
+
+cfg_win! {
+    fn main() {
+        panic!("This example is not supported on Windows");
+    }
+}

--- a/examples/embassy-net/src/main.rs
+++ b/examples/embassy-net/src/main.rs
@@ -65,7 +65,7 @@ cfg_unix! {
 
     use core::net::{IpAddr, SocketAddr};
     use std::time::SystemTime;
-    
+
     const NTP_SERVER: &str = "pool.ntp.org";
 
     #[derive(Copy, Clone, Default)]


### PR DESCRIPTION
Got the example from #36 and slightly modify it to leave only required dependencies and/or features.

This example demonstrates fetching the current time from an NTP server via a TUN/TAP interface using `embassy-net` and `sntpc`. It includes setup instructions for configuring the network interface and running the example. The implementation provides a reusable template for asynchronous networking with Embassy's executor.