### PR TITLE
sntpc: Add async API unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,6 @@ jobs:
           cargo build -p sntpc --no-default-features
           cargo build -p example-simple-no-std --profile no-std
       - name: Run tests with std
-        run: cargo test
+        run: cargo test --all-features
       - name: Run tests with no_std
         run: cargo test --no-default-features

--- a/sntpc/src/lib.rs
+++ b/sntpc/src/lib.rs
@@ -1248,6 +1248,11 @@ mod sntpc_ntp_result_tests {
             assert_eq!(offset, expected);
         }
     }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod sntpc_std_tests {
+    use crate::types::Units;
 
     #[test]
     fn test_units_str_representation() {

--- a/sntpc/src/lib.rs
+++ b/sntpc/src/lib.rs
@@ -1072,10 +1072,43 @@ pub fn fraction_to_picoseconds(sec_fraction: u32) -> u64 {
 
 #[cfg(test)]
 mod sntpc_ntp_result_tests {
+    use crate::types::Units;
     use crate::{
         fraction_to_microseconds, fraction_to_milliseconds,
-        fraction_to_nanoseconds, fraction_to_picoseconds, NtpResult,
+        fraction_to_nanoseconds, fraction_to_picoseconds, offset_calculate,
+        NtpResult,
     };
+
+    struct Timestamps(u64, u64, u64, u64);
+    struct OffsetCalcTestCase {
+        timestamp: Timestamps,
+        expected: i64,
+    }
+
+    impl OffsetCalcTestCase {
+        fn new(t1: u64, t2: u64, t3: u64, t4: u64, expected: i64) -> Self {
+            OffsetCalcTestCase {
+                timestamp: Timestamps(t1, t2, t3, t4),
+                expected,
+            }
+        }
+
+        fn t1(&self) -> u64 {
+            self.timestamp.0
+        }
+
+        fn t2(&self) -> u64 {
+            self.timestamp.1
+        }
+
+        fn t3(&self) -> u64 {
+            self.timestamp.2
+        }
+
+        fn t4(&self) -> u64 {
+            self.timestamp.3
+        }
+    }
 
     #[test]
     fn test_ntp_result() {
@@ -1169,44 +1202,65 @@ mod sntpc_ntp_result_tests {
         let picoseconds = fraction_to_picoseconds(result.seconds_fraction);
         assert_eq!(0u64, picoseconds);
     }
+
+    #[test]
+    fn test_offset_calculate() {
+        let tests = [
+            OffsetCalcTestCase::new(
+                16_893_142_954_672_769_962,
+                16_893_142_959_053_084_959,
+                16_893_142_959_053_112_968,
+                16_893_142_954_793_063_406,
+                1_005_870,
+            ),
+            OffsetCalcTestCase::new(
+                16_893_362_966_131_575_843,
+                16_893_362_966_715_800_791,
+                16_893_362_966_715_869_584,
+                16_893_362_967_084_349_913,
+                25115,
+            ),
+            OffsetCalcTestCase::new(
+                16_893_399_716_399_327_198,
+                16_893_399_716_453_045_029,
+                16_893_399_716_453_098_083,
+                16_893_399_716_961_924_964,
+                -52981,
+            ),
+            OffsetCalcTestCase::new(
+                9_487_534_663_484_046_772u64,
+                16_882_120_099_581_835_046u64,
+                16_882_120_099_583_884_144u64,
+                9_487_534_663_651_464_597u64,
+                1_721_686_086_620_926,
+            ),
+        ];
+
+        for t in tests {
+            let offset = offset_calculate(
+                t.t1(),
+                t.t2(),
+                t.t3(),
+                t.t4(),
+                Units::Microseconds,
+            );
+            let expected = t.expected;
+            assert_eq!(offset, expected);
+        }
+    }
+
+    #[test]
+    fn test_units_str_representation() {
+        assert_eq!(format!("{}", Units::Milliseconds), "ms");
+        assert_eq!(format!("{}", Units::Microseconds), "us");
+    }
 }
 
 #[cfg(all(test, feature = "std", feature = "std-socket", feature = "sync"))]
-mod sntpc_tests {
+mod sntpc_sync_tests {
     use crate::sync::get_time;
-    use crate::{offset_calculate, Error, NtpContext, StdTimestampGen, Units};
+    use crate::{Error, NtpContext, StdTimestampGen};
     use std::net::{ToSocketAddrs, UdpSocket};
-
-    struct Timestamps(u64, u64, u64, u64);
-    struct OffsetCalcTestCase {
-        timestamp: Timestamps,
-        expected: i64,
-    }
-
-    impl OffsetCalcTestCase {
-        fn new(t1: u64, t2: u64, t3: u64, t4: u64, expected: i64) -> Self {
-            OffsetCalcTestCase {
-                timestamp: Timestamps(t1, t2, t3, t4),
-                expected,
-            }
-        }
-
-        fn t1(&self) -> u64 {
-            self.timestamp.0
-        }
-
-        fn t2(&self) -> u64 {
-            self.timestamp.1
-        }
-
-        fn t3(&self) -> u64 {
-            self.timestamp.2
-        }
-
-        fn t4(&self) -> u64 {
-            self.timestamp.3
-        }
-    }
 
     #[test]
     fn test_ntp_request_sntpv4_supported() {
@@ -1273,56 +1327,68 @@ mod sntpc_tests {
         let result = pool.to_socket_addrs();
         assert!(result.is_err(), "{pool} is ok");
     }
+}
+
+#[cfg(all(test, feature = "std", feature = "std-socket"))]
+mod sntpc_async_tests {
+    use crate::get_time;
+    use crate::{Error, NtpContext, StdTimestampGen};
+    use miniloop::executor::Executor;
+    use std::net::{ToSocketAddrs, UdpSocket};
 
     #[test]
-    fn test_units_str_representation() {
-        assert_eq!(format!("{}", Units::Milliseconds), "ms");
-        assert_eq!(format!("{}", Units::Microseconds), "us");
+    fn test_ntp_async_request_sntpv4_supported() {
+        let context = NtpContext::new(StdTimestampGen::default());
+        let pools = [
+            "pool.ntp.org:123",
+            "time.google.com:123",
+            "time.apple.com:123",
+            "time.cloudflare.com:123",
+            "time.facebook.com:123",
+        ];
+
+        for pool in &pools {
+            let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+            socket
+                .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .expect("Unable to set up socket timeout");
+
+            for address in pool.to_socket_addrs().unwrap() {
+                let result = Executor::new()
+                    .block_on(get_time(address, &socket, context));
+
+                assert!(
+                    result.is_ok(),
+                    "{} is bad - {:?}",
+                    pool,
+                    result.unwrap_err()
+                );
+                assert_ne!(result.unwrap().seconds, 0);
+            }
+        }
     }
 
     #[test]
-    fn test_offset_calculate() {
-        let tests = [
-            OffsetCalcTestCase::new(
-                16_893_142_954_672_769_962,
-                16_893_142_959_053_084_959,
-                16_893_142_959_053_112_968,
-                16_893_142_954_793_063_406,
-                1_005_870,
-            ),
-            OffsetCalcTestCase::new(
-                16_893_362_966_131_575_843,
-                16_893_362_966_715_800_791,
-                16_893_362_966_715_869_584,
-                16_893_362_967_084_349_913,
-                25115,
-            ),
-            OffsetCalcTestCase::new(
-                16_893_399_716_399_327_198,
-                16_893_399_716_453_045_029,
-                16_893_399_716_453_098_083,
-                16_893_399_716_961_924_964,
-                -52981,
-            ),
-            OffsetCalcTestCase::new(
-                9_487_534_663_484_046_772u64,
-                16_882_120_099_581_835_046u64,
-                16_882_120_099_583_884_144u64,
-                9_487_534_663_651_464_597u64,
-                1_721_686_086_620_926,
-            ),
-        ];
+    fn test_ntp_async_request_sntpv3_not_supported() {
+        let context = NtpContext::new(StdTimestampGen::default());
 
-        for t in tests {
-            let offset = offset_calculate(
-                t.t1(),
-                t.t2(),
-                t.t3(),
-                t.t4(),
-                Units::Microseconds,
-            );
-            let expected = t.expected;
-            assert_eq!(offset, expected);
+        let pools = ["time.nist.gov:123", "time.windows.com:123"];
+
+        for pool in &pools {
+            let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+            socket
+                .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .expect("Unable to set up socket timeout");
+
+            for address in pool.to_socket_addrs().unwrap() {
+                let result = Executor::new()
+                    .block_on(get_time(address, &socket, context));
+                assert!(result.is_err(), "{pool} is ok");
+                assert_eq!(
+                    result.unwrap_err(),
+                    Error::IncorrectResponseVersion
+                );
+            }
         }
     }
 }

--- a/sntpc/src/lib.rs
+++ b/sntpc/src/lib.rs
@@ -1260,7 +1260,7 @@ mod sntpc_ntp_result_tests {
 mod sntpc_sync_tests {
     use crate::sync::get_time;
     use crate::{Error, NtpContext, StdTimestampGen};
-    use std::net::{ToSocketAddrs, UdpSocket};
+    use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
 
     #[test]
     fn test_ntp_request_sntpv4_supported() {
@@ -1279,7 +1279,9 @@ mod sntpc_sync_tests {
                 .set_read_timeout(Some(std::time::Duration::from_secs(2)))
                 .expect("Unable to set up socket timeout");
 
-            for address in pool.to_socket_addrs().unwrap() {
+            for address in
+                pool.to_socket_addrs().unwrap().filter(SocketAddr::is_ipv4)
+            {
                 let result = get_time(address, &socket, context);
 
                 assert!(
@@ -1302,10 +1304,12 @@ mod sntpc_sync_tests {
         for pool in &pools {
             let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
             socket
-                .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
                 .expect("Unable to set up socket timeout");
 
-            for address in pool.to_socket_addrs().unwrap() {
+            for address in
+                pool.to_socket_addrs().unwrap().filter(SocketAddr::is_ipv4)
+            {
                 let result = get_time(address, &socket, context);
                 assert!(result.is_err(), "{pool} is ok");
                 assert_eq!(
@@ -1321,7 +1325,7 @@ mod sntpc_sync_tests {
         let pool = "asdf.asdf.asdf:123";
         let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
         socket
-            .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
             .expect("Unable to set up socket timeout");
 
         let result = pool.to_socket_addrs();
@@ -1334,7 +1338,7 @@ mod sntpc_async_tests {
     use crate::get_time;
     use crate::{Error, NtpContext, StdTimestampGen};
     use miniloop::executor::Executor;
-    use std::net::{ToSocketAddrs, UdpSocket};
+    use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
 
     #[test]
     fn test_ntp_async_request_sntpv4_supported() {
@@ -1350,17 +1354,18 @@ mod sntpc_async_tests {
         for pool in &pools {
             let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
             socket
-                .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
                 .expect("Unable to set up socket timeout");
 
-            for address in pool.to_socket_addrs().unwrap() {
+            for address in
+                pool.to_socket_addrs().unwrap().filter(SocketAddr::is_ipv4)
+            {
                 let result = Executor::new()
                     .block_on(get_time(address, &socket, context));
 
                 assert!(
                     result.is_ok(),
-                    "{} is bad - {:?}",
-                    pool,
+                    "{pool} is bad - {:?}",
                     result.unwrap_err()
                 );
                 assert_ne!(result.unwrap().seconds, 0);
@@ -1377,10 +1382,12 @@ mod sntpc_async_tests {
         for pool in &pools {
             let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
             socket
-                .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
                 .expect("Unable to set up socket timeout");
 
-            for address in pool.to_socket_addrs().unwrap() {
+            for address in
+                pool.to_socket_addrs().unwrap().filter(SocketAddr::is_ipv4)
+            {
                 let result = Executor::new()
                     .block_on(get_time(address, &socket, context));
                 assert!(result.is_err(), "{pool} is ok");


### PR DESCRIPTION
Introduced new tests to verify the correctness of `offset_calculate` with diverse scenarios and edge cases. Added async tests for both supported (SNTPv4) and unsupported (SNTPv3) NTP protocols, ensuring compatibility and proper error handling. Reorganized test modules for better clarity and separation of sync and async tests.

Fix: #39