### PR TITLE
Clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ fn main() {
         .set_read_timeout(Some(Duration::from_secs(2)))
         .expect("Unable to set UDP socket read timeout");
 
-    for addr in POOL_NTP_ADDR.to_socket_addrs().filter(SocketAddr::is_ipv4).unwrap() {
+    for addr in POOL_NTP_ADDR.to_socket_addrs().unwrap() {
         let ntp_context = NtpContext::new(StdTimestampGen::default());
         let result = get_time(addr, &socket, ntp_context);
 

--- a/examples/simple-request/Cargo.toml
+++ b/examples/simple-request/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [features]
-log = ["dep:simple_logger", "dep:log"]
+log = ["dep:simple_logger", "dep:log", "sntpc/log"]
 
 [dependencies]
 sntpc = { path = "../../sntpc", features = ["sync"] }

--- a/examples/smoltcp-request/Cargo.toml
+++ b/examples/smoltcp-request/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [features]
-log = ["dep:simple_logger", "dep:log"]
+log = ["dep:simple_logger", "dep:log", "sntpc/log"]
 
 [dependencies]
 sntpc = { path = "../../sntpc", features = ["sync"] }

--- a/examples/timesync/Cargo.toml
+++ b/examples/timesync/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [features]
-log = ["dep:simple_logger", "dep:log"]
+log = ["dep:simple_logger", "dep:log", "sntpc/log"]
 
 [dependencies]
 sntpc = { path = "../../sntpc", default-features = false, features = ["utils", "sync"] }

--- a/sntpc/Cargo.toml
+++ b/sntpc/Cargo.toml
@@ -37,6 +37,7 @@ miniloop = { version = "~0.3", optional = true }
 embassy-net = { version = "0.5.0", features = ["udp", "proto-ipv4", "proto-ipv6", "medium-ip"], optional = true }
 tokio = { version = "1", features = ["net"], optional = true }
 defmt = { version = "0.3", optional = true }
+cfg-if = "~1"
 
 [dev-dependencies]
 miniloop = "~0.3"

--- a/sntpc/src/log.rs
+++ b/sntpc/src/log.rs
@@ -1,0 +1,10 @@
+#![allow(unused_imports)]
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "defmt")] {
+        pub(crate) use defmt::{debug, error};
+    } else if #[cfg(feature = "log")] {
+        pub(crate) use log::{debug, error};
+    }
+}

--- a/sntpc/src/socket/embassy.rs
+++ b/sntpc/src/socket/embassy.rs
@@ -1,12 +1,9 @@
+#[cfg(any(feature = "log", feature = "defmt"))]
+use crate::log::error;
 use crate::{net::SocketAddr, Error, NtpUdpSocket, Result};
 use embassy_net::{udp::UdpSocket, IpAddress, IpEndpoint};
 
 use core::net::IpAddr;
-
-#[cfg(feature = "defmt")]
-use defmt::error;
-#[cfg(all(feature = "log", not(feature = "defmt")))]
-use log::error;
 
 impl NtpUdpSocket for UdpSocket<'_> {
     async fn send_to(&self, buf: &[u8], addr: SocketAddr) -> Result<usize> {

--- a/sntpc/src/utils.rs
+++ b/sntpc/src/utils.rs
@@ -1,13 +1,11 @@
 //! Helper utils to synchronize time of a system
 //!
 //! Currently, Unix and Windows based systems are supported
-#[cfg(feature = "log")]
+#[cfg(any(feature = "log", feature = "defmt"))]
+use crate::log::debug;
+#[cfg(any(feature = "log", feature = "defmt"))]
 use chrono::Timelike;
 use chrono::{Local, TimeZone, Utc};
-#[cfg(feature = "defmt")]
-use defmt::debug;
-#[cfg(all(feature = "log", not(feature = "defmt")))]
-use log::debug;
 
 #[cfg(unix)]
 use unix::sync_time;


### PR DESCRIPTION
### Description
- Refactor debug logging for NTP packet inspection and introduce a new logging module that conditionally supports `defmt` or `log` based on the enabled feature.
- Unified logging behavior by combining `log` and `defmt` feature flags to ensure consistent debug logging support.
- Simplify logging imports by consolidating under a single conditional directive, maintaining compatibility with both `log` and `defmt` features.