### PR TITLE
Add support for embassy-net v0.6.0

### DIFF
--- a/sntpc/Cargo.toml
+++ b/sntpc/Cargo.toml
@@ -34,7 +34,7 @@ defmt = ["dep:defmt", "embassy-net/defmt"]
 log = { version = "~0.4", optional = true }
 chrono = { version = "~0.4", default-features = false, optional = true }
 miniloop = { version = "~0.3", optional = true }
-embassy-net = { version = "0.5.0", features = ["udp", "proto-ipv4", "proto-ipv6", "medium-ip"], optional = true }
+embassy-net = { version = ">=0.5,<0.7", features = ["udp", "proto-ipv4", "proto-ipv6", "medium-ip"], optional = true }
 tokio = { version = "1", features = ["net"], optional = true }
 defmt = { version = "0.3", optional = true }
 cfg-if = "~1"

--- a/sntpc/src/types.rs
+++ b/sntpc/src/types.rs
@@ -38,6 +38,7 @@ pub(crate) const SECONDS_FRAC_MASK: u64 = 0xffff_ffff;
 /// SNTP library result type
 pub type Result<T> = core::result::Result<T, Error>;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct NtpPacket {
     pub(crate) li_vn_mode: u8,
     pub(crate) stratum: u8,
@@ -58,6 +59,7 @@ cfg_if! {
 
         use core::str;
 
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub(crate) struct DebugNtpPacket<'a> {
             packet: &'a NtpPacket,
             client_recv_timestamp: u64,


### PR DESCRIPTION
`embassy-net` v0.6.0 has recently been released.  This PR adds build support for v0.6.0 and addresses a couple of missing `defmt::Format` traits which were causing a compilation error when the `defmt` feature is enabled.

Note: I have tested that sntpc works with embassy-net v0.6.0.