### PR TITLE
bump embassy crate versions, make ipv6 opt-in

### DIFF
--- a/sntpc/Cargo.toml
+++ b/sntpc/Cargo.toml
@@ -26,15 +26,16 @@ sync = ["dep:miniloop"]
 utils = ["std", "dep:chrono", "chrono/clock"]
 log = ["dep:log"]
 std-socket = []
-embassy-socket = ["dep:embassy-net"]
 tokio-socket = ["dep:tokio"]
 defmt = ["dep:defmt", "embassy-net/defmt"]
+embassy-socket = ["dep:embassy-net"]
+embassy-socket-ipv6 = ["embassy-socket", "embassy-net?/proto-ipv6"]
 
 [dependencies]
 log = { version = "~0.4", optional = true }
 chrono = { version = "~0.4", default-features = false, optional = true }
 miniloop = { version = "~0.3", optional = true }
-embassy-net = { version = ">=0.5", features = ["udp", "proto-ipv4", "proto-ipv6", "medium-ip"], optional = true }
+embassy-net = { version = "0.6", features = ["udp", "proto-ipv4", "medium-ip"], optional = true }
 tokio = { version = "1", features = ["net"], optional = true }
 defmt = { version = "0.3", optional = true }
 cfg-if = "~1"

--- a/sntpc/src/socket/embassy.rs
+++ b/sntpc/src/socket/embassy.rs
@@ -11,7 +11,10 @@ impl NtpUdpSocket for UdpSocket<'_> {
         let endpoint = IpEndpoint::new(
             match addr.ip() {
                 IpAddr::V4(addr) => IpAddress::Ipv4(addr),
+                #[cfg(feature = "embassy-socket-ipv6")]
                 IpAddr::V6(addr) => IpAddress::Ipv6(addr),
+                #[allow(unreachable_patterns)]
+                _ => unreachable!(),
             },
             addr.port(),
         );
@@ -31,7 +34,10 @@ impl NtpUdpSocket for UdpSocket<'_> {
             SocketAddr::new(
                 match ep.addr {
                     IpAddress::Ipv4(val) => IpAddr::V4(val),
+                    #[cfg(feature = "embassy-socket-ipv6")]
                     IpAddress::Ipv6(val) => IpAddr::V6(val),
+                    #[allow(unreachable_patterns)]
+                    _ => unreachable!(),
                 },
                 ep.port,
             )


### PR DESCRIPTION
Thanks for the library!

This PR updates embassy to the latest released version. It also makes ipv6 opt in, on my target enabling ipv6 uses too much flash, so I need to support ipv4 only.