### PR TITLE
cargo: allow embassy-net-0.9 that works without code change

### DIFF
--- a/sntpc-net-embassy/Cargo.toml
+++ b/sntpc-net-embassy/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace = true
 
 [dependencies]
 sntpc = { version = "~0.9", path = "../sntpc", default-features = false }
-embassy-net = { version = ">=0.8, <0.9", default-features = false, features = ["udp", "proto-ipv4", "medium-ip"] }
+embassy-net = { version = ">=0.9, <0.10", default-features = false, features = ["udp", "proto-ipv4", "medium-ip"] }
 
 cfg-if = { version = "1", optional = true }
 log = { version = "~0.4", optional = true }


### PR DESCRIPTION
Thank you for this great project.
While updating dependencies on my hobby project, I found that `sntpc-net-embassy` was working without code change with `embassy-net-0.9`. The changelog is at https://github.com/embassy-rs/embassy/blob/main/embassy-net/CHANGELOG.md#090---2026-03-10 
A new version of `sntpc-net-embassy` would be appreciated.
