### PR TITLE
Fix get_time(...) doc about seconds fractions.

### DIFF
--- a/sntpc-net-embassy/src/lib.rs
+++ b/sntpc-net-embassy/src/lib.rs
@@ -34,7 +34,10 @@
 //!
 //! let result = get_time(server_addr, &socket, ntp_context).await;
 //! match result {
-//!     Ok(time) => defmt::info!("Received time: {}.{}", time.sec(), time.sec_fraction()),
+//!     Ok(time) => {
+//!         let subseconds = time.sec_fraction() * 1_000_000 / u64::from(u32::MAX);
+//!         defmt::info!("Received time: {}.{}", time.sec(), subseconds)
+//!     }
 //!     Err(e) => defmt::error!("Failed to get time: {:?}", e),
 //! }
 //! ```


### PR DESCRIPTION
The `fraction()` do not directly represent the part after the decimal. To get the sub-second precision decimals one has to compute them from the fractions.

More details can be found in example:
https://github.com/vpetrigo/sntpc/blob/f5a163913096d6d25c0a0d97e4a8a80e48e731a2/examples/simple-no-std/src/main.rs#L113