### PR TITLE
Update implementation to have RFC 5905 protocol correctness

### DIFF
--- a/sntpc/src/lib.rs
+++ b/sntpc/src/lib.rs
@@ -583,7 +583,7 @@ fn validate_response(packet: &NtpPacket, send_req_result: &SendRequestResult) ->
     }
 
     // Root distance validation (RFC 5905 §A.5.1.1)
-    // root_delay/2 + root_dispersion must be < MAXDISP
+    // `root_delay/2 + root_dispersion` must be < `MAXDISP`
     if (packet.root_delay / 2).saturating_add(packet.root_dispersion) >= MAXDISP {
         return Err(Error::ExcessiveRootDistance);
     }

--- a/sntpc/src/lib.rs
+++ b/sntpc/src/lib.rs
@@ -440,7 +440,7 @@ pub mod sync {
     /// Returns an `Err` if the underlying async SNTP response processing fails for any reason,
     /// such as:
     /// - Incorrect origin timestamp in the response,
-    /// - An invalid mode in the response (`SNTP_UNICAST` or `SNTP_BROADCAST`),
+    /// - An invalid mode in the response (`SNTP_UNICAST`),
     /// - A mismatch between the request and response versions,
     /// - Errors in the response headers (e.g., incorrect stratum, leap indicator),
     /// - Network errors during processing.
@@ -490,9 +490,6 @@ pub mod sync {
 
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
 fn process_response(send_req_result: SendRequestResult, resp: RawNtpPacket, recv_timestamp: u64) -> Result<NtpResult> {
-    const SNTP_UNICAST: u8 = 4;
-    const SNTP_BROADCAST: u8 = 5;
-    const LI_MAX_VALUE: u8 = 3;
     let mut packet = NtpPacket::from(resp);
 
     convert_from_network(&mut packet);
@@ -504,34 +501,7 @@ fn process_response(send_req_result: SendRequestResult, resp: RawNtpPacket, recv
         }
     );
 
-    if send_req_result.originate_timestamp != packet.origin_timestamp {
-        return Err(Error::IncorrectOriginTimestamp);
-    }
-    // Shift is 0
-    let mode = shifter(packet.li_vn_mode, MODE_MASK, MODE_SHIFT);
-    let li = shifter(packet.li_vn_mode, LI_MASK, LI_SHIFT);
-    let resp_version = shifter(packet.li_vn_mode, VERSION_MASK, VERSION_SHIFT);
-    let req_version = shifter(send_req_result.version, VERSION_MASK, VERSION_SHIFT);
-
-    if mode != SNTP_UNICAST && mode != SNTP_BROADCAST {
-        return Err(Error::IncorrectMode);
-    }
-
-    if li > LI_MAX_VALUE {
-        return Err(Error::IncorrectLeapIndicator);
-    }
-
-    if req_version != resp_version {
-        return Err(Error::IncorrectResponseVersion);
-    }
-
-    if packet.stratum == 0 {
-        return Err(Error::KissOfDeath(KissOfDeathCode::new(packet.ref_id.to_be_bytes())));
-    }
-
-    if packet.stratum >= 16 {
-        return Err(Error::IncorrectStratumHeaders);
-    }
+    validate_response(&packet, &send_req_result)?;
     // System clock offset:
     // theta = T(B) - T(A) = 1/2 * [(T2-T1) + (T3-T4)]
     // Round-trip delay:
@@ -549,6 +519,7 @@ fn process_response(send_req_result: SendRequestResult, resp: RawNtpPacket, recv
     let roundtrip = roundtrip_calculate(t1, t2, t3, t4, units);
     let offset = offset_calculate(t1, t2, t3, t4, units);
     let timestamp = NtpTimestamp::from(packet.tx_timestamp);
+    let li = shifter(packet.li_vn_mode, LI_MASK, LI_SHIFT);
 
     #[cfg(any(feature = "log", feature = "defmt"))]
     debug!("Roundtrip delay: {} {}. Offset: {} {}", roundtrip, units, offset, units);
@@ -560,7 +531,68 @@ fn process_response(send_req_result: SendRequestResult, resp: RawNtpPacket, recv
         offset,
         packet.stratum,
         packet.precision,
+        li,
     ))
+}
+
+/// Validate an NTP response packet according to RFC 5905 §A.5.1.1
+fn validate_response(packet: &NtpPacket, send_req_result: &SendRequestResult) -> Result<()> {
+    // Origin timestamp check
+    if send_req_result.originate_timestamp != packet.origin_timestamp {
+        return Err(Error::IncorrectOriginTimestamp);
+    }
+
+    let mode = shifter(packet.li_vn_mode, MODE_MASK, MODE_SHIFT);
+    let li = shifter(packet.li_vn_mode, LI_MASK, LI_SHIFT);
+    let resp_version = shifter(packet.li_vn_mode, VERSION_MASK, VERSION_SHIFT);
+    let req_version = shifter(send_req_result.version, VERSION_MASK, VERSION_SHIFT);
+
+    // Mode check: only unicast (mode 4) is supported.
+    // Broadcast mode (mode 5) is not supported. See RFC 5905 §14 for broadcast client requirements.
+    if mode != SNTP_UNICAST {
+        return Err(Error::IncorrectMode);
+    }
+
+    // Kiss-of-death check (stratum 0 indicates KoD packet)
+    // Must be checked BEFORE LI check, because KoD packets may have LI=3 and should
+    // be identified as KoD rather than UnsynchronizedClock.
+    if packet.stratum == 0 {
+        return Err(Error::KissOfDeath(KissOfDeathCode::from_bytes(
+            packet.ref_id.to_be_bytes(),
+        )));
+    }
+
+    // Leap indicator check: LI=3 means clock unsynchronized per RFC 5905 §7.3 Figure 9
+    if li == LI_UNSYNCHRONIZED {
+        return Err(Error::UnsynchronizedClock);
+    }
+
+    // Version check
+    if req_version != resp_version {
+        return Err(Error::IncorrectResponseVersion);
+    }
+
+    // Stratum check
+    if packet.stratum >= 16 {
+        return Err(Error::IncorrectStratumHeaders);
+    }
+
+    // Zero transmit timestamp check (RFC 5905 §A.5.1.1, RFC 4330 §5)
+    if packet.tx_timestamp == 0 {
+        return Err(Error::InvalidTimestamp);
+    }
+
+    // Root distance validation (RFC 5905 §A.5.1.1)
+    // root_delay/2 + root_dispersion must be < MAXDISP
+    if (packet.root_delay / 2).saturating_add(packet.root_dispersion) >= MAXDISP {
+        return Err(Error::ExcessiveRootDistance);
+    }
+    // Reference timestamp must not be newer than transmit timestamp
+    if packet.ref_timestamp > packet.tx_timestamp {
+        return Err(Error::BackwardReferenceTimestamp);
+    }
+
+    Ok(())
 }
 
 fn shifter(val: u8, mask: u8, shift: u8) -> u8 {
@@ -586,7 +618,12 @@ fn convert_delays(sec: u64, fraction: u64, units: u64) -> u64 {
 }
 
 fn roundtrip_calculate(t1: u64, t2: u64, t3: u64, t4: u64, units: Units) -> u64 {
-    let delta = t4.wrapping_sub(t1).saturating_sub(t3.wrapping_sub(t2));
+    // delta = (T4 - T1) - (T3 - T2)
+    // If T4 < T1 or T3 < T2, saturating_sub gives zero for that component.
+    // If (T4 - T1) < (T3 - T2), delay would be negative — clamp to 0.
+    let outbound = t4.saturating_sub(t1);
+    let server_time = t3.saturating_sub(t2);
+    let delta = outbound.saturating_sub(server_time);
     let delta_sec = (delta & SECONDS_MASK) >> 32;
     let delta_sec_fraction = delta & SECONDS_FRAC_MASK;
 
@@ -648,6 +685,7 @@ pub fn fraction_to_picoseconds(sec_fraction: u32) -> u64 {
 #[cfg(test)]
 mod sntpc_ntp_result_tests {
     use crate::offset_calculate;
+    use crate::roundtrip_calculate;
     use crate::types::Units;
 
     struct Timestamps(u64, u64, u64, u64);
@@ -765,5 +803,44 @@ mod sntpc_ntp_result_tests {
     fn test_units_str_representation() {
         assert_eq!(format!("{}", Units::Milliseconds), "ms");
         assert_eq!(format!("{}", Units::Microseconds), "us");
+    }
+
+    #[test]
+    fn test_roundtrip_calculate_normal() {
+        // Normal case: T4 > T1, T3 > T2, positive delay
+        let t1 = 1_000_000_000u64;
+        let t2 = 1_000_010_000u64;
+        let t3 = 1_000_020_000u64;
+        let t4 = 1_000_030_000u64;
+        let result = roundtrip_calculate(t1, t2, t3, t4, Units::Microseconds);
+        assert!(result > 0);
+    }
+
+    #[test]
+    fn test_roundtrip_calculate_clock_backward() {
+        // T4 < T1 (clock went backward) — should clamp to 0
+        let t1 = 2_000_000_000u64;
+        let t2 = 1_000_010_000u64;
+        let t3 = 1_000_020_000u64;
+        let t4 = 1_000_030_000u64;
+        let result = roundtrip_calculate(t1, t2, t3, t4, Units::Microseconds);
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_roundtrip_calculate_negative_delay() {
+        // (T4-T1) < (T3-T2) — negative delay, should clamp to 0
+        let t1 = 1_000_000_000u64;
+        let t2 = 1_000_100_000u64;
+        let t3 = 1_000_200_000u64;
+        let t4 = 1_000_050_000u64;
+        let result = roundtrip_calculate(t1, t2, t3, t4, Units::Microseconds);
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_roundtrip_calculate_all_zeros() {
+        let result = roundtrip_calculate(0, 0, 0, 0, Units::Microseconds);
+        assert_eq!(result, 0);
     }
 }

--- a/sntpc/src/types.rs
+++ b/sntpc/src/types.rs
@@ -10,6 +10,10 @@ use core::fmt::{Debug, Display};
 use core::future::Future;
 use core::mem;
 
+/// SNTP unicast mode constant
+pub(crate) const SNTP_UNICAST: u8 = 4;
+/// Maximum allowed root distance (16 seconds in NTP short format: 16 << 16)
+pub(crate) const MAXDISP: u32 = 0x0010_0000;
 /// SNTP mode value bit mask
 pub(crate) const MODE_MASK: u8 = 0b0000_0111;
 /// SNTP mode bit mask shift value
@@ -22,6 +26,8 @@ pub(crate) const VERSION_SHIFT: u8 = 3;
 pub(crate) const LI_MASK: u8 = 0b1100_0000;
 /// SNTP LI bit mask shift value
 pub(crate) const LI_SHIFT: u8 = 6;
+/// SNTP LI unsynchronized value
+pub(crate) const LI_UNSYNCHRONIZED: u8 = 3;
 /// SNTP picoseconds in second constant
 pub(crate) const PSEC_IN_SEC: u64 = 1_000_000_000_000;
 /// SNTP nanoseconds in second constant
@@ -167,7 +173,7 @@ impl KissOfDeathCode {
     ///
     /// # Parameters
     /// - `code`: An array of 4 bytes representing the kiss-o'-death code.
-    pub(crate) fn new(code: [u8; 4]) -> Self {
+    pub(crate) fn from_bytes(code: [u8; 4]) -> Self {
         Self { code }
     }
 
@@ -193,8 +199,14 @@ pub enum Error {
     IncorrectOriginTimestamp,
     /// Incorrect mode value in a NTP response
     IncorrectMode,
-    /// Incorrect Leap Indicator (LI) value in a NTP response
-    IncorrectLeapIndicator,
+    /// Incorrect Leap Indicator (LI) value in a NTP response (LI=3 means clock unsynchronized)
+    UnsynchronizedClock,
+    /// NTP response contains an invalid timestamp (e.g., zero transmit timestamp)
+    InvalidTimestamp,
+    /// Root distance (root_delay/2 + root_dispersion) exceeds maximum allowed value (MAXDISP)
+    ExcessiveRootDistance,
+    /// Reference timestamp is newer than transmit timestamp, indicating invalid server data
+    BackwardReferenceTimestamp,
     /// Incorrect version in a NTP response. Currently, `SNTPv4` is supported
     IncorrectResponseVersion,
     /// Incorrect stratum headers in a NTP response
@@ -228,10 +240,24 @@ pub struct NtpResult {
     pub stratum: u8,
     /// Precision of NTP server as log2(seconds) - this should usually be negative
     pub precision: i8,
+    /// Leap Indicator (LI) value from the server response
+    /// - 0: no warning
+    /// - 1: last minute has 61 seconds
+    /// - 2: last minute has 59 seconds
+    /// - 3: clock unsynchronized (alarm condition)
+    pub leap_indicator: u8,
 }
 
 impl NtpResult {
     /// Create new NTP result
+    ///
+    /// # Note
+    ///
+    /// The `seconds_fraction` value is normalized: if it equals or exceeds `u32::MAX`,
+    /// the excess is carried into `seconds`. Specifically:
+    /// - `seconds` becomes `seconds + seconds_fraction / u32::MAX`
+    /// - `seconds_fraction` becomes `seconds_fraction % u32::MAX`
+    ///
     /// Args:
     /// * `seconds` - number of seconds
     /// * `seconds_fraction` - number of seconds fraction
@@ -239,8 +265,17 @@ impl NtpResult {
     /// * `offset` - calculated system clock offset in microseconds
     /// * `stratum` - integer indicating the stratum (level of server's hierarchy to stratum 0 - "reference clock")
     /// * `precision` - an exponent of two, where the resulting value is the precision of the system clock in seconds
+    /// * `leap_indicator` - leap indicator value from the server response (0-3)
     #[must_use]
-    pub fn new(seconds: u32, seconds_fraction: u32, roundtrip: u64, offset: i64, stratum: u8, precision: i8) -> Self {
+    pub fn new(
+        seconds: u32,
+        seconds_fraction: u32,
+        roundtrip: u64,
+        offset: i64,
+        stratum: u8,
+        precision: i8,
+        leap_indicator: u8,
+    ) -> Self {
         let seconds = seconds + seconds_fraction / u32::MAX;
         let seconds_fraction = seconds_fraction % u32::MAX;
 
@@ -251,6 +286,7 @@ impl NtpResult {
             offset,
             stratum,
             precision,
+            leap_indicator,
         }
     }
     /// Returns number of seconds reported by an NTP server
@@ -287,6 +323,17 @@ impl NtpResult {
     #[must_use]
     pub fn precision(&self) -> i8 {
         self.precision
+    }
+
+    /// Returns the leap indicator (LI) from the server response
+    ///
+    /// - 0: no warning
+    /// - 1: last minute has 61 seconds
+    /// - 2: last minute has 59 seconds
+    /// - 3: clock unsynchronized (alarm condition)
+    #[must_use]
+    pub fn leap_indicator(&self) -> u8 {
+        self.leap_indicator
     }
 }
 

--- a/sntpc/src/types.rs
+++ b/sntpc/src/types.rs
@@ -203,7 +203,7 @@ pub enum Error {
     UnsynchronizedClock,
     /// NTP response contains an invalid timestamp (e.g., zero transmit timestamp)
     InvalidTimestamp,
-    /// Root distance (root_delay/2 + root_dispersion) exceeds maximum allowed value (MAXDISP)
+    /// Root distance (`root_delay/2 + root_dispersion`) exceeds maximum allowed value (`MAXDISP`)
     ExcessiveRootDistance,
     /// Reference timestamp is newer than transmit timestamp, indicating invalid server data
     BackwardReferenceTimestamp,

--- a/sntpc/tests/basic.rs
+++ b/sntpc/tests/basic.rs
@@ -4,7 +4,7 @@ use sntpc::{
 
 #[test]
 fn test_ntp_result() {
-    let result1 = NtpResult::new(0, 0, 0, 0, 1, -2);
+    let result1 = NtpResult::new(0, 0, 0, 0, 1, -2, 0);
 
     assert_eq!(0, result1.sec());
     assert_eq!(0, result1.sec_fraction());
@@ -12,8 +12,9 @@ fn test_ntp_result() {
     assert_eq!(0, result1.offset());
     assert_eq!(1, result1.stratum());
     assert_eq!(-2, result1.precision());
+    assert_eq!(0, result1.leap_indicator());
 
-    let result2 = NtpResult::new(1, 2, 3, 4, 5, -23);
+    let result2 = NtpResult::new(1, 2, 3, 4, 5, -23, 1);
 
     assert_eq!(1, result2.sec());
     assert_eq!(2, result2.sec_fraction());
@@ -21,25 +22,27 @@ fn test_ntp_result() {
     assert_eq!(4, result2.offset());
     assert_eq!(5, result2.stratum());
     assert_eq!(-23, result2.precision());
+    assert_eq!(1, result2.leap_indicator());
 
-    let result3 = NtpResult::new(u32::MAX - 1, u32::MAX, u64::MAX, i64::MAX, 1, -127);
+    let result3 = NtpResult::new(u32::MAX - 1, u32::MAX, u64::MAX, i64::MAX, 1, -127, 2);
 
     assert_eq!(u32::MAX, result3.sec());
     assert_eq!(0, result3.sec_fraction());
     assert_eq!(u64::MAX, result3.roundtrip());
     assert_eq!(i64::MAX, result3.offset());
     assert_eq!(-127, result3.precision());
+    assert_eq!(2, result3.leap_indicator());
 }
 
 #[test]
 fn test_ntp_fraction_overflow_result() {
-    let result = NtpResult::new(0, u32::MAX, 0, 0, 1, -19);
+    let result = NtpResult::new(0, u32::MAX, 0, 0, 1, -19, 0);
     assert_eq!(1, result.sec());
     assert_eq!(0, result.sec_fraction());
     assert_eq!(0, result.roundtrip());
     assert_eq!(0, result.offset());
 
-    let result = NtpResult::new(u32::MAX - 1, u32::MAX, 0, 0, 1, -17);
+    let result = NtpResult::new(u32::MAX - 1, u32::MAX, 0, 0, 1, -17, 0);
     assert_eq!(u32::MAX, result.sec());
     assert_eq!(0, result.sec_fraction());
     assert_eq!(0, result.roundtrip());
@@ -48,48 +51,48 @@ fn test_ntp_fraction_overflow_result() {
 
 #[test]
 fn test_conversion_to_ms() {
-    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0);
+    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0, 0);
     let milliseconds = fraction_to_milliseconds(result.seconds_fraction);
     assert_eq!(999u32, milliseconds);
 
-    let result = NtpResult::new(0, 0, 0, 0, 1, 0);
+    let result = NtpResult::new(0, 0, 0, 0, 1, 0, 0);
     let milliseconds = fraction_to_milliseconds(result.seconds_fraction);
     assert_eq!(0u32, milliseconds);
 }
 
 #[test]
 fn test_conversion_to_us() {
-    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0);
+    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0, 0);
     let microseconds = fraction_to_microseconds(result.seconds_fraction);
     assert_eq!(999_999u32, microseconds);
 
-    let result = NtpResult::new(0, 0, 0, 0, 1, 0);
+    let result = NtpResult::new(0, 0, 0, 0, 1, 0, 0);
     let microseconds = fraction_to_microseconds(result.seconds_fraction);
     assert_eq!(0u32, microseconds);
 }
 
 #[test]
 fn test_conversion_to_ns() {
-    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0);
+    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0, 0);
     let nanoseconds = fraction_to_nanoseconds(result.seconds_fraction);
     assert_eq!(999_999_999u32, nanoseconds);
 
-    let result = NtpResult::new(0, 0, 0, 0, 1, 0);
+    let result = NtpResult::new(0, 0, 0, 0, 1, 0, 0);
     let nanoseconds = fraction_to_nanoseconds(result.seconds_fraction);
     assert_eq!(0u32, nanoseconds);
 }
 
 #[test]
 fn test_conversion_to_ps() {
-    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0);
+    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0, 0);
     let picoseconds = fraction_to_picoseconds(result.seconds_fraction);
     assert_eq!(999_999_999_767u64, picoseconds);
 
-    let result = NtpResult::new(0, 1, 0, 0, 1, 0);
+    let result = NtpResult::new(0, 1, 0, 0, 1, 0, 0);
     let picoseconds = fraction_to_picoseconds(result.seconds_fraction);
     assert_eq!(232u64, picoseconds);
 
-    let result = NtpResult::new(0, 0, 0, 0, 1, 0);
+    let result = NtpResult::new(0, 0, 0, 0, 1, 0, 0);
     let picoseconds = fraction_to_picoseconds(result.seconds_fraction);
     assert_eq!(0u64, picoseconds);
 }

--- a/sntpc/tests/helpers/mod.rs
+++ b/sntpc/tests/helpers/mod.rs
@@ -1,4 +1,4 @@
-use sntpc::{Error, NtpContext, NtpTimestampGenerator, NtpUdpSocket, sntp_process_response, sntp_send_request};
+use sntpc::{NtpTimestampGenerator, NtpUdpSocket};
 use std::net::SocketAddr;
 
 #[derive(Default, Copy, Clone)]
@@ -50,47 +50,5 @@ impl NtpUdpSocket for MockUdpSocket {
         buf.copy_from_slice(&self.read);
 
         self.read_result
-    }
-}
-
-#[test]
-fn test_kiss_of_death() {
-    let defined_codes = [
-        "ACST", "AUTH", "AUTO", "BCST", "CRYP", "DENY", "DROP", "RSTR", "INIT", "MCST", "NKEY", "RATE", "RMOT", "STEP",
-    ];
-
-    for code in defined_codes {
-        let dest: SocketAddr = "127.0.0.1:123".parse().unwrap();
-        let data = {
-            const TIMESTAMP: u64 = 9_487_534_653_230_284_800u64;
-            let mut data = [0u8; 48];
-
-            data[0] = 0xE4;
-            data[12..16].copy_from_slice(code.as_bytes());
-            data[24..32].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
-            data
-        };
-
-        let mut socket = MockUdpSocket::new(dest, data);
-
-        socket.update_read_result(Ok((data.len(), dest)));
-
-        let context = NtpContext::new(MockTimestampGen);
-        let mut executor: miniloop::executor::Executor<1> = miniloop::executor::Executor::new();
-        let mut handler: miniloop::task::Handle<()> = miniloop::task::Handle::default();
-        let mut task = miniloop::task::Task::new("test", async {
-            let result = sntp_send_request(dest, &socket, context).await;
-            assert!(result.is_ok());
-            let result = sntp_process_response(dest, &socket, context, result.unwrap()).await;
-
-            match result.unwrap_err() {
-                Error::KissOfDeath(kod_code) => assert_eq!(kod_code.as_str(), code),
-                _ => unreachable!("Unexpected error code"),
-            }
-        });
-
-        let _ = executor.spawn(&mut task, &mut handler);
-
-        executor.run();
     }
 }

--- a/sntpc/tests/net.rs
+++ b/sntpc/tests/net.rs
@@ -104,12 +104,12 @@ fn test_process_incorrect_payload() {
 
 #[test]
 fn test_process_incorrect_mode() {
-    const PROPER_SNTP_MODE1: u8 = 4;
-    const PROPER_SNTP_MODE2: u8 = 5;
+    const PROPER_SNTP_MODE: u8 = 4;
     let dest: SocketAddr = "127.0.0.1:123".parse().unwrap();
     let context = NtpContext::new(MockTimestampGen);
 
-    for i in (0..=0b111u8).filter(|&i| (i != PROPER_SNTP_MODE1) && (i != PROPER_SNTP_MODE2)) {
+    // All modes except 4 should be rejected (broadcast mode 5 is also rejected)
+    for i in (0..=0b111u8).filter(|&i| i != PROPER_SNTP_MODE) {
         let data = {
             const TIMESTAMP: u64 = 9_487_534_653_230_284_800u64;
             let mut data = [0u8; 48];
@@ -146,6 +146,7 @@ fn test_process_incorrect_response_version() {
             let mut data = [0u8; 48];
 
             data[0] = 4 | (i << 3);
+            data[1] = 1; // non-zero stratum to avoid KoD check
             data[24..32].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
             data
         };
@@ -209,9 +210,10 @@ fn test_kiss_of_death() {
             const TIMESTAMP: u64 = 9_487_534_653_230_284_800u64;
             let mut data = [0u8; 48];
 
-            data[0] = 0xE4;
+            data[0] = 0x24; // LI=0, VN=4, mode=4
             data[12..16].copy_from_slice(code.as_bytes());
             data[24..32].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
+            data[40..48].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
             data
         };
 
@@ -264,4 +266,132 @@ fn test_process_incorrect_origin_timestamp() {
 
     assert!(result.is_err());
     assert!(matches!(result, Err(Error::IncorrectOriginTimestamp)));
+}
+
+#[test]
+fn test_unsynchronized_clock() {
+    let dest: SocketAddr = "127.0.0.1:123".parse().unwrap();
+    let context = NtpContext::new(MockTimestampGen);
+
+    let data = {
+        const TIMESTAMP: u64 = 9_487_534_653_230_284_800u64;
+        let mut data = [0u8; 48];
+
+        // LI=3, VN=4, mode=4 => 0b11_100_100 = 0xE4
+        data[0] = 0xE4;
+        data[1] = 1;
+        data[24..32].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
+        data
+    };
+
+    let mut socket = MockUdpSocket::new(dest, data);
+    socket.update_write_result(Ok(48));
+    socket.update_read_result(Ok((48, dest)));
+    let mut executor: miniloop::executor::Executor<1> = miniloop::executor::Executor::new();
+    let result = executor.block_on(async {
+        let resp = sntp_send_request(dest, &socket, context).await;
+
+        sntp_process_response(dest, &socket, context, resp.unwrap()).await
+    });
+
+    assert!(result.is_err());
+    assert!(matches!(result, Err(Error::UnsynchronizedClock)));
+}
+
+#[test]
+fn test_invalid_timestamp() {
+    let dest: SocketAddr = "127.0.0.1:123".parse().unwrap();
+    let context = NtpContext::new(MockTimestampGen);
+
+    // Packet with zero transmit timestamp
+    let data = {
+        const TIMESTAMP: u64 = 9_487_534_653_230_284_800u64;
+        let mut data = [0u8; 48];
+
+        data[0] = 0x24; // LI=0, VN=4, mode=4
+        data[1] = 1; // stratum 1
+        data[24..32].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
+        // tx_timestamp stays as 0 (default)
+        data
+    };
+
+    let mut socket = MockUdpSocket::new(dest, data);
+    socket.update_write_result(Ok(48));
+    socket.update_read_result(Ok((48, dest)));
+    let mut executor: miniloop::executor::Executor<1> = miniloop::executor::Executor::new();
+    let result = executor.block_on(async {
+        let resp = sntp_send_request(dest, &socket, context).await;
+
+        sntp_process_response(dest, &socket, context, resp.unwrap()).await
+    });
+
+    assert!(result.is_err());
+    assert!(matches!(result, Err(Error::InvalidTimestamp)));
+}
+
+#[test]
+fn test_invalid_root_distance() {
+    let dest: SocketAddr = "127.0.0.1:123".parse().unwrap();
+    let context = NtpContext::new(MockTimestampGen);
+
+    // Packet with root_delay/2 + root_dispersion >= MAXDISP
+    let data = {
+        const TIMESTAMP: u64 = 9_487_534_653_230_284_800u64;
+        let mut data = [0u8; 48];
+
+        data[0] = 0x24; // LI=0, VN=4, mode=4
+        data[1] = 1; // stratum 1
+        // root_delay = 0x0020_0000 (32 seconds in NTP short format)
+        data[4..8].copy_from_slice(&(0x0020_0000u32).to_be_bytes());
+        // root_dispersion = 0 (so root_delay/2 + root_disp = 0x0010_0000 = MAXDISP => should be rejected)
+        data[24..32].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
+        data[40..48].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
+        data
+    };
+
+    let mut socket = MockUdpSocket::new(dest, data);
+    socket.update_write_result(Ok(48));
+    socket.update_read_result(Ok((48, dest)));
+    let mut executor: miniloop::executor::Executor<1> = miniloop::executor::Executor::new();
+    let result = executor.block_on(async {
+        let resp = sntp_send_request(dest, &socket, context).await;
+
+        sntp_process_response(dest, &socket, context, resp.unwrap()).await
+    });
+
+    assert!(result.is_err());
+    assert!(matches!(result, Err(Error::ExcessiveRootDistance)));
+}
+
+#[test]
+fn test_ref_timestamp_newer_than_tx_timestamp() {
+    let dest: SocketAddr = "127.0.0.1:123".parse().unwrap();
+    let context = NtpContext::new(MockTimestampGen);
+
+    // Packet with ref_timestamp > tx_timestamp
+    let data = {
+        const TX_TIMESTAMP: u64 = 9_487_534_653_230_284_800u64;
+        const REF_TIMESTAMP: u64 = 9_487_534_653_230_284_801u64; // newer than tx
+        let mut data = [0u8; 48];
+
+        data[0] = 0x24; // LI=0, VN=4, mode=4
+        data[1] = 1; // stratum 1
+        data[16..24].copy_from_slice(REF_TIMESTAMP.to_be_bytes().as_ref());
+        data[24..32].copy_from_slice(TX_TIMESTAMP.to_be_bytes().as_ref());
+        data[40..48].copy_from_slice(TX_TIMESTAMP.to_be_bytes().as_ref());
+        data
+    };
+
+    let mut socket = MockUdpSocket::new(dest, data);
+    socket.update_write_result(Ok(48));
+    socket.update_read_result(Ok((48, dest)));
+    let mut executor: miniloop::executor::Executor<1> = miniloop::executor::Executor::new();
+    let result = executor.block_on(async {
+        let resp = sntp_send_request(dest, &socket, context).await;
+
+        sntp_process_response(dest, &socket, context, resp.unwrap()).await
+    });
+
+    assert!(result.is_err());
+    assert!(matches!(result, Err(Error::BackwardReferenceTimestamp)));
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 publish = false
 
@@ -8,5 +8,5 @@ publish = false
 clap = { version = "~4", features = ["derive"] }
 anyhow = "1.0"
 colored = "3.0.0"
-toml = "~0.9"
+toml = "1.1.2+spec-1.1.0"
 glob = "~0.3"


### PR DESCRIPTION
- Fix LI validation: reject LI=3 (unsynchronized clock) instead of dead li>3 check
- Swap KoD check before LI check for correct diagnostic priority
- Remove broadcast mode (mode 5) acceptance - not supported
- Clamp negative delay to 0 using saturating_sub (RFC 5905 section 8)