### PR TITLE
Kiss-of-Death enum redesign

### DIFF
--- a/sntpc/src/types.rs
+++ b/sntpc/src/types.rs
@@ -8,7 +8,6 @@ use cfg_if::cfg_if;
 use core::fmt::Formatter;
 use core::fmt::{Debug, Display};
 use core::future::Future;
-use core::mem;
 
 /// SNTP unicast mode constant
 pub(crate) const SNTP_UNICAST: u8 = 4;
@@ -161,30 +160,104 @@ impl Display for Units {
     }
 }
 
-// Kiss-o'-Death value representation
-#[derive(Debug, Copy, Clone, PartialEq)]
+/// Kiss-o'-Death code received from an NTP server (RFC 5905 §7.4).
+///
+/// When a server sends a packet with stratum 0, the Reference Identifier field
+/// carries a 4-character ASCII kiss code. Different codes require different
+/// client actions:
+///
+/// - `Deny` and `Rstr`: The client MUST demobilize the association and stop
+///   sending packets to that server.
+/// - `Rate`: The client MUST immediately reduce its polling interval and
+///   continue to reduce it each time it receives a RATE kiss code.
+/// - `Experimental`: Codes beginning with 'X' are for unregistered
+///   experimentation and MUST be ignored if not recognized.
+/// - All other codes: No protocol significance; discard after inspection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct KissOfDeathCode {
-    code: [u8; 4],
+#[non_exhaustive]
+pub enum KissOfDeathCode {
+    /// ACST: The association belongs to a unicast server
+    Acst,
+    /// AUTH: Server authentication failed
+    Auth,
+    /// AUTO: Autokey sequence failed
+    Auto,
+    /// BCST: The association belongs to a broadcast server
+    Bcst,
+    /// CRYP: Cryptographic authentication or identification failed
+    Cryp,
+    /// DENY: Access denied by remote server
+    Deny,
+    /// DROP: Lost peer in symmetric mode
+    Drop,
+    /// RSTR: Access denied due to local policy
+    Rstr,
+    /// INIT: The association has not yet synchronized for the first time
+    Init,
+    /// MCST: The association belongs to a dynamically discovered server
+    Mcst,
+    /// NKEY: No key found
+    Nkey,
+    /// RATE: Rate exceeded — client MUST reduce a polling interval
+    Rate,
+    /// RMOT: Alteration of association from a remote host
+    Rmot,
+    /// STEP: A step change in system time has occurred
+    Step,
+    /// Experimental/unregistered code (the first byte is 'X' per RFC 5905 §7.4)
+    Experimental([u8; 4]),
 }
 
 impl KissOfDeathCode {
-    /// Creates a new instance of the struct with the specified 4-byte code.
+    /// Creates a new instance from a 4-byte code.
     ///
-    /// # Parameters
-    /// - `code`: An array of 4 bytes representing the kiss-o'-death code.
+    /// If the bytes match a known RFC 5905 §7.4 kiss code, the corresponding
+    /// variant is returned. Otherwise, the code is wrapped in `Experimental`.
     pub(crate) fn from_bytes(code: [u8; 4]) -> Self {
-        Self { code }
+        match &code {
+            b"ACST" => Self::Acst,
+            b"AUTH" => Self::Auth,
+            b"AUTO" => Self::Auto,
+            b"BCST" => Self::Bcst,
+            b"CRYP" => Self::Cryp,
+            b"DENY" => Self::Deny,
+            b"DROP" => Self::Drop,
+            b"RSTR" => Self::Rstr,
+            b"INIT" => Self::Init,
+            b"MCST" => Self::Mcst,
+            b"NKEY" => Self::Nkey,
+            b"RATE" => Self::Rate,
+            b"RMOT" => Self::Rmot,
+            b"STEP" => Self::Step,
+            _ => Self::Experimental(code),
+        }
     }
 
-    /// Converts the internal code representation to a string slice (`&str`).
+    /// Returns the 4-character ASCII string representation of the kiss code.
     ///
-    /// This method attempts to interpret the bytes of the internal code as valid UTF-8,
-    /// returning the corresponding string slice. If the internal code is not valid UTF-8,
-    /// it will return an empty string (`""`).
+    /// For known variants, the standard code string (e.g., `"DENY"`, `"RATE"`) is returned.
+    /// For `Experimental` codes, the raw bytes are interpreted as UTF-8; if not valid UTF-8,
+    /// an empty string (`""`) is returned.
     #[must_use]
     pub fn as_str(&self) -> &str {
-        str::from_utf8(&self.code).unwrap_or("")
+        match self {
+            Self::Acst => "ACST",
+            Self::Auth => "AUTH",
+            Self::Auto => "AUTO",
+            Self::Bcst => "BCST",
+            Self::Cryp => "CRYP",
+            Self::Deny => "DENY",
+            Self::Drop => "DROP",
+            Self::Rstr => "RSTR",
+            Self::Init => "INIT",
+            Self::Mcst => "MCST",
+            Self::Nkey => "NKEY",
+            Self::Rate => "RATE",
+            Self::Rmot => "RMOT",
+            Self::Step => "STEP",
+            Self::Experimental(code) => str::from_utf8(code).unwrap_or(""),
+        }
     }
 }
 
@@ -220,7 +293,15 @@ pub enum Error {
     /// A NTP server address response has been received from does not match
     /// to the address the request was sent to
     ResponseAddressMismatch,
-    /// Kiss-o'-Death packet received from a NTP server
+    /// Kiss-o'-Death packet received from an NTP server (RFC 5905 §7.4).
+    ///
+    /// The embedded `KissOfDeathCode` indicates why the server rejected the request.
+    /// Depending on the code, the caller may need to take specific actions:
+    /// - `Deny` / `Rstr`: The client MUST demobilize the association and stop
+    ///   sending packets to that server.
+    /// - `Rate`: The client MUST immediately reduce its polling interval and
+    ///   continue to reduce it each time RATE is received.
+    /// - All other codes: No required protocol action; inspect and discard.
     KissOfDeath(KissOfDeathCode),
 }
 
@@ -531,12 +612,12 @@ impl From<RawNtpPacket> for NtpPacket {
         // }
         // see: https://github.com/vpetrigo/sntpc/issues/34
         let to_array_u32 = |x: &[u8]| {
-            let mut temp_buf = [0u8; mem::size_of::<u32>()];
+            let mut temp_buf = [0u8; size_of::<u32>()];
             temp_buf.copy_from_slice(x);
             temp_buf
         };
         let to_array_u64 = |x: &[u8]| {
-            let mut temp_buf = [0u8; mem::size_of::<u64>()];
+            let mut temp_buf = [0u8; size_of::<u64>()];
             temp_buf.copy_from_slice(x);
             temp_buf
         };

--- a/sntpc/tests/net.rs
+++ b/sntpc/tests/net.rs
@@ -1,7 +1,7 @@
 mod helpers;
 
 use helpers::*;
-use sntpc::{Error, NtpContext, sntp_process_response, sntp_send_request};
+use sntpc::{Error, KissOfDeathCode, NtpContext, sntp_process_response, sntp_send_request};
 
 use core::net::SocketAddr;
 
@@ -200,18 +200,31 @@ fn test_process_incorrect_stratum() {
 
 #[test]
 fn test_kiss_of_death() {
-    let defined_codes = [
-        "ACST", "AUTH", "AUTO", "BCST", "CRYP", "DENY", "DROP", "RSTR", "INIT", "MCST", "NKEY", "RATE", "RMOT", "STEP",
+    let defined_codes: [(&str, KissOfDeathCode); 14] = [
+        ("ACST", KissOfDeathCode::Acst),
+        ("AUTH", KissOfDeathCode::Auth),
+        ("AUTO", KissOfDeathCode::Auto),
+        ("BCST", KissOfDeathCode::Bcst),
+        ("CRYP", KissOfDeathCode::Cryp),
+        ("DENY", KissOfDeathCode::Deny),
+        ("DROP", KissOfDeathCode::Drop),
+        ("RSTR", KissOfDeathCode::Rstr),
+        ("INIT", KissOfDeathCode::Init),
+        ("MCST", KissOfDeathCode::Mcst),
+        ("NKEY", KissOfDeathCode::Nkey),
+        ("RATE", KissOfDeathCode::Rate),
+        ("RMOT", KissOfDeathCode::Rmot),
+        ("STEP", KissOfDeathCode::Step),
     ];
 
-    for code in defined_codes {
+    for &(code_str, expected_variant) in &defined_codes {
         let dest: SocketAddr = "127.0.0.1:123".parse().unwrap();
         let data = {
             const TIMESTAMP: u64 = 9_487_534_653_230_284_800u64;
             let mut data = [0u8; 48];
 
             data[0] = 0x24; // LI=0, VN=4, mode=4
-            data[12..16].copy_from_slice(code.as_bytes());
+            data[12..16].copy_from_slice(code_str.as_bytes());
             data[24..32].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
             data[40..48].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
             data
@@ -230,7 +243,10 @@ fn test_kiss_of_death() {
             let result = sntp_process_response(dest, &socket, context, result.unwrap()).await;
 
             match result.unwrap_err() {
-                Error::KissOfDeath(kod_code) => assert_eq!(kod_code.as_str(), code),
+                Error::KissOfDeath(kod_code) => {
+                    assert_eq!(kod_code, expected_variant);
+                    assert_eq!(kod_code.as_str(), code_str);
+                }
                 _ => unreachable!("Unexpected error code"),
             }
         });
@@ -239,6 +255,86 @@ fn test_kiss_of_death() {
 
         executor.run();
     }
+}
+
+#[test]
+fn test_kiss_of_death_experimental() {
+    // X-prefixed codes should return Experimental variant
+    let code = *b"XABC";
+    let dest: SocketAddr = "127.0.0.1:123".parse().unwrap();
+    let data = {
+        const TIMESTAMP: u64 = 9_487_534_653_230_284_800u64;
+        let mut data = [0u8; 48];
+
+        data[0] = 0x24; // LI=0, VN=4, mode=4
+        data[12..16].copy_from_slice(&code);
+        data[24..32].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
+        data[40..48].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
+        data
+    };
+
+    let mut socket = MockUdpSocket::new(dest, data);
+    socket.update_read_result(Ok((data.len(), dest)));
+
+    let context = NtpContext::new(MockTimestampGen);
+    let mut executor: miniloop::executor::Executor<1> = miniloop::executor::Executor::new();
+    let mut handler: miniloop::task::Handle<()> = miniloop::task::Handle::default();
+    let mut task = miniloop::task::Task::new("test", async {
+        let result = sntp_send_request(dest, &socket, context).await;
+        assert!(result.is_ok());
+        let result = sntp_process_response(dest, &socket, context, result.unwrap()).await;
+
+        match result.unwrap_err() {
+            Error::KissOfDeath(KissOfDeathCode::Experimental(inner)) => {
+                assert_eq!(inner, code);
+                assert_eq!(KissOfDeathCode::Experimental(code).as_str(), "XABC");
+            }
+            _ => unreachable!("Expected Experimental KoD"),
+        }
+    });
+
+    let _ = executor.spawn(&mut task, &mut handler);
+    executor.run();
+}
+
+#[test]
+fn test_kiss_of_death_unknown() {
+    // Unknown non-X codes should also return Experimental variant
+    let code = *b"ZZZZ";
+    let dest: SocketAddr = "127.0.0.1:123".parse().unwrap();
+    let data = {
+        const TIMESTAMP: u64 = 9_487_534_653_230_284_800u64;
+        let mut data = [0u8; 48];
+
+        data[0] = 0x24; // LI=0, VN=4, mode=4
+        data[12..16].copy_from_slice(&code);
+        data[24..32].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
+        data[40..48].copy_from_slice(TIMESTAMP.to_be_bytes().as_ref());
+        data
+    };
+
+    let mut socket = MockUdpSocket::new(dest, data);
+    socket.update_read_result(Ok((data.len(), dest)));
+
+    let context = NtpContext::new(MockTimestampGen);
+    let mut executor: miniloop::executor::Executor<1> = miniloop::executor::Executor::new();
+    let mut handler: miniloop::task::Handle<()> = miniloop::task::Handle::default();
+    let mut task = miniloop::task::Task::new("test", async {
+        let result = sntp_send_request(dest, &socket, context).await;
+        assert!(result.is_ok());
+        let result = sntp_process_response(dest, &socket, context, result.unwrap()).await;
+
+        match result.unwrap_err() {
+            Error::KissOfDeath(KissOfDeathCode::Experimental(inner)) => {
+                assert_eq!(inner, code);
+                assert_eq!(KissOfDeathCode::Experimental(code).as_str(), "ZZZZ");
+            }
+            _ => unreachable!("Expected Experimental KoD"),
+        }
+    });
+
+    let _ = executor.spawn(&mut task, &mut handler);
+    executor.run();
 }
 
 #[test]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 clap = { version = "~4", features = ["derive"] }
 anyhow = "1.0"
 colored = "3.0.0"
-toml = "1.1.2+spec-1.1.0"
+toml = "~1.1"
 glob = "~0.3"


### PR DESCRIPTION
- Redesign KissOfDeathCode from struct to #[non_exhaustive] enum
- 14 named variants per RFC 5905 section 7.4: Acst, Auth, Auto, Bcst, Cryp, Deny, Drop, Rstr, Init, Mcst, Nkey, Rate, Rmot, Step
- Add tests for experimental and unknown kiss codes
