### PR TITLE
Expose missing NtpResult fields

### DIFF
--- a/sntpc/src/lib.rs
+++ b/sntpc/src/lib.rs
@@ -488,7 +488,7 @@ pub mod sync {
     }
 }
 
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn process_response(send_req_result: SendRequestResult, resp: RawNtpPacket, recv_timestamp: u64) -> Result<NtpResult> {
     let mut packet = NtpPacket::from(resp);
 
@@ -534,7 +534,7 @@ fn process_response(send_req_result: SendRequestResult, resp: RawNtpPacket, recv
         li,
         packet.root_delay,
         packet.root_dispersion,
-        packet.ref_id.to_be_bytes(),  // Convert to network byte order for external use
+        packet.ref_id.to_be_bytes(), // Convert to network byte order for external use
         packet.ref_timestamp,
         packet.poll,
     ))

--- a/sntpc/src/lib.rs
+++ b/sntpc/src/lib.rs
@@ -532,6 +532,11 @@ fn process_response(send_req_result: SendRequestResult, resp: RawNtpPacket, recv
         packet.stratum,
         packet.precision,
         li,
+        packet.root_delay,
+        packet.root_dispersion,
+        packet.ref_id.to_be_bytes(),  // Convert to network byte order for external use
+        packet.ref_timestamp,
+        packet.poll,
     ))
 }
 

--- a/sntpc/src/types.rs
+++ b/sntpc/src/types.rs
@@ -306,6 +306,14 @@ pub enum Error {
 }
 
 /// SNTP request result representation
+///
+/// # NTP Short Format
+///
+/// The `root_delay` and `root_dispersion` fields use NTP short format (16.16 fixed-point),
+/// where the upper 16 bits represent seconds and the lower 16 bits represent a fraction
+/// of a second (1/65536). To convert to seconds:
+/// - `seconds = value >> 16`
+/// - `fraction = value & 0xFFFF` (where fraction represents 1/65536 of a second)
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct NtpResult {
@@ -327,6 +335,18 @@ pub struct NtpResult {
     /// - 2: last minute has 59 seconds
     /// - 3: clock unsynchronized (alarm condition)
     pub leap_indicator: u8,
+    /// Root delay: total round-trip delay to the reference clock in NTP short format (16.16 fixed-point)
+    pub root_delay: u32,
+    /// Root dispersion: total dispersion to the reference clock in NTP short format (16.16 fixed-point)
+    pub root_dispersion: u32,
+    /// Reference identifier: for stratum 0 (kiss code), stratum 1 (4-char ASCII clock identifier),
+    /// or stratum 2+ (IPv4 address or MD5 hash of IPv6 address). In network byte order.
+    pub reference_id: [u8; 4],
+    /// Reference timestamp: time when the server's clock was last set or corrected,
+    /// in NTP timestamp format (seconds since 1900-01-01 with 32-bit fraction)
+    pub reference_timestamp: u64,
+    /// Poll interval: maximum interval between successive messages, in log2 seconds
+    pub poll: i8,
 }
 
 impl NtpResult {
@@ -347,7 +367,13 @@ impl NtpResult {
     /// * `stratum` - integer indicating the stratum (level of server's hierarchy to stratum 0 - "reference clock")
     /// * `precision` - an exponent of two, where the resulting value is the precision of the system clock in seconds
     /// * `leap_indicator` - leap indicator value from the server response (0-3)
+    /// * `root_delay` - total round-trip delay to the reference clock in NTP short format (16.16 fixed-point)
+    /// * `root_dispersion` - total dispersion to the reference clock in NTP short format (16.16 fixed-point)
+    /// * `reference_id` - reference identifier as 4-byte array in network byte order
+    /// * `reference_timestamp` - reference timestamp in NTP timestamp format
+    /// * `poll` - poll interval in log2 seconds
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         seconds: u32,
         seconds_fraction: u32,
@@ -356,6 +382,11 @@ impl NtpResult {
         stratum: u8,
         precision: i8,
         leap_indicator: u8,
+        root_delay: u32,
+        root_dispersion: u32,
+        reference_id: [u8; 4],
+        reference_timestamp: u64,
+        poll: i8,
     ) -> Self {
         let seconds = seconds + seconds_fraction / u32::MAX;
         let seconds_fraction = seconds_fraction % u32::MAX;
@@ -368,6 +399,11 @@ impl NtpResult {
             stratum,
             precision,
             leap_indicator,
+            root_delay,
+            root_dispersion,
+            reference_id,
+            reference_timestamp,
+            poll,
         }
     }
     /// Returns number of seconds reported by an NTP server
@@ -415,6 +451,42 @@ impl NtpResult {
     #[must_use]
     pub fn leap_indicator(&self) -> u8 {
         self.leap_indicator
+    }
+
+    /// Returns the root delay in NTP short format (16.16 fixed-point)
+    #[must_use]
+    pub fn root_delay(&self) -> u32 {
+        self.root_delay
+    }
+
+    /// Returns the root dispersion in NTP short format (16.16 fixed-point)
+    #[must_use]
+    pub fn root_dispersion(&self) -> u32 {
+        self.root_dispersion
+    }
+
+    /// Returns the reference identifier as a 4-byte array in network byte order.
+    ///
+    /// Interpretation depends on stratum:
+    /// - Stratum 0: Kiss-o'-Death ASCII code
+    /// - Stratum 1: 4-character ASCII reference clock identifier (e.g., "GPS", "PPS")
+    /// - Stratum 2+: IPv4 address (or first 4 bytes of MD5 hash of IPv6 address)
+    #[must_use]
+    pub fn reference_id(&self) -> [u8; 4] {
+        self.reference_id
+    }
+
+    /// Returns the reference timestamp in NTP timestamp format
+    /// (seconds since 1900-01-01 with 32-bit fraction)
+    #[must_use]
+    pub fn reference_timestamp(&self) -> u64 {
+        self.reference_timestamp
+    }
+
+    /// Returns the poll interval as log2 seconds
+    #[must_use]
+    pub fn poll(&self) -> i8 {
+        self.poll
     }
 }
 

--- a/sntpc/tests/basic.rs
+++ b/sntpc/tests/basic.rs
@@ -4,7 +4,7 @@ use sntpc::{
 
 #[test]
 fn test_ntp_result() {
-    let result1 = NtpResult::new(0, 0, 0, 0, 1, -2, 0);
+    let result1 = NtpResult::new(0, 0, 0, 0, 1, -2, 0, 0, 0, [0; 4], 0, 0);
 
     assert_eq!(0, result1.sec());
     assert_eq!(0, result1.sec_fraction());
@@ -13,8 +13,13 @@ fn test_ntp_result() {
     assert_eq!(1, result1.stratum());
     assert_eq!(-2, result1.precision());
     assert_eq!(0, result1.leap_indicator());
+    assert_eq!(0, result1.root_delay());
+    assert_eq!(0, result1.root_dispersion());
+    assert_eq!([0; 4], result1.reference_id());
+    assert_eq!(0, result1.reference_timestamp());
+    assert_eq!(0, result1.poll());
 
-    let result2 = NtpResult::new(1, 2, 3, 4, 5, -23, 1);
+    let result2 = NtpResult::new(1, 2, 3, 4, 5, -23, 1, 0, 0, [0; 4], 0, 0);
 
     assert_eq!(1, result2.sec());
     assert_eq!(2, result2.sec_fraction());
@@ -23,8 +28,13 @@ fn test_ntp_result() {
     assert_eq!(5, result2.stratum());
     assert_eq!(-23, result2.precision());
     assert_eq!(1, result2.leap_indicator());
+    assert_eq!(0, result2.root_delay());
+    assert_eq!(0, result2.root_dispersion());
+    assert_eq!([0; 4], result2.reference_id());
+    assert_eq!(0, result2.reference_timestamp());
+    assert_eq!(0, result2.poll());
 
-    let result3 = NtpResult::new(u32::MAX - 1, u32::MAX, u64::MAX, i64::MAX, 1, -127, 2);
+    let result3 = NtpResult::new(u32::MAX - 1, u32::MAX, u64::MAX, i64::MAX, 1, -127, 2, 0, 0, [0; 4], 0, 0);
 
     assert_eq!(u32::MAX, result3.sec());
     assert_eq!(0, result3.sec_fraction());
@@ -36,13 +46,13 @@ fn test_ntp_result() {
 
 #[test]
 fn test_ntp_fraction_overflow_result() {
-    let result = NtpResult::new(0, u32::MAX, 0, 0, 1, -19, 0);
+    let result = NtpResult::new(0, u32::MAX, 0, 0, 1, -19, 0, 0, 0, [0; 4], 0, 0);
     assert_eq!(1, result.sec());
     assert_eq!(0, result.sec_fraction());
     assert_eq!(0, result.roundtrip());
     assert_eq!(0, result.offset());
 
-    let result = NtpResult::new(u32::MAX - 1, u32::MAX, 0, 0, 1, -17, 0);
+    let result = NtpResult::new(u32::MAX - 1, u32::MAX, 0, 0, 1, -17, 0, 0, 0, [0; 4], 0, 0);
     assert_eq!(u32::MAX, result.sec());
     assert_eq!(0, result.sec_fraction());
     assert_eq!(0, result.roundtrip());
@@ -51,48 +61,48 @@ fn test_ntp_fraction_overflow_result() {
 
 #[test]
 fn test_conversion_to_ms() {
-    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0, 0);
+    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0, 0, 0, 0, [0; 4], 0, 0);
     let milliseconds = fraction_to_milliseconds(result.seconds_fraction);
     assert_eq!(999u32, milliseconds);
 
-    let result = NtpResult::new(0, 0, 0, 0, 1, 0, 0);
+    let result = NtpResult::new(0, 0, 0, 0, 1, 0, 0, 0, 0, [0; 4], 0, 0);
     let milliseconds = fraction_to_milliseconds(result.seconds_fraction);
     assert_eq!(0u32, milliseconds);
 }
 
 #[test]
 fn test_conversion_to_us() {
-    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0, 0);
+    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0, 0, 0, 0, [0; 4], 0, 0);
     let microseconds = fraction_to_microseconds(result.seconds_fraction);
     assert_eq!(999_999u32, microseconds);
 
-    let result = NtpResult::new(0, 0, 0, 0, 1, 0, 0);
+    let result = NtpResult::new(0, 0, 0, 0, 1, 0, 0, 0, 0, [0; 4], 0, 0);
     let microseconds = fraction_to_microseconds(result.seconds_fraction);
     assert_eq!(0u32, microseconds);
 }
 
 #[test]
 fn test_conversion_to_ns() {
-    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0, 0);
+    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0, 0, 0, 0, [0; 4], 0, 0);
     let nanoseconds = fraction_to_nanoseconds(result.seconds_fraction);
     assert_eq!(999_999_999u32, nanoseconds);
 
-    let result = NtpResult::new(0, 0, 0, 0, 1, 0, 0);
+    let result = NtpResult::new(0, 0, 0, 0, 1, 0, 0, 0, 0, [0; 4], 0, 0);
     let nanoseconds = fraction_to_nanoseconds(result.seconds_fraction);
     assert_eq!(0u32, nanoseconds);
 }
 
 #[test]
 fn test_conversion_to_ps() {
-    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0, 0);
+    let result = NtpResult::new(0, u32::MAX - 1, 0, 0, 1, 0, 0, 0, 0, [0; 4], 0, 0);
     let picoseconds = fraction_to_picoseconds(result.seconds_fraction);
     assert_eq!(999_999_999_767u64, picoseconds);
 
-    let result = NtpResult::new(0, 1, 0, 0, 1, 0, 0);
+    let result = NtpResult::new(0, 1, 0, 0, 1, 0, 0, 0, 0, [0; 4], 0, 0);
     let picoseconds = fraction_to_picoseconds(result.seconds_fraction);
     assert_eq!(232u64, picoseconds);
 
-    let result = NtpResult::new(0, 0, 0, 0, 1, 0, 0);
+    let result = NtpResult::new(0, 0, 0, 0, 1, 0, 0, 0, 0, [0; 4], 0, 0);
     let picoseconds = fraction_to_picoseconds(result.seconds_fraction);
     assert_eq!(0u64, picoseconds);
 }

--- a/sntpc/tests/basic.rs
+++ b/sntpc/tests/basic.rs
@@ -34,7 +34,20 @@ fn test_ntp_result() {
     assert_eq!(0, result2.reference_timestamp());
     assert_eq!(0, result2.poll());
 
-    let result3 = NtpResult::new(u32::MAX - 1, u32::MAX, u64::MAX, i64::MAX, 1, -127, 2, 0, 0, [0; 4], 0, 0);
+    let result3 = NtpResult::new(
+        u32::MAX - 1,
+        u32::MAX,
+        u64::MAX,
+        i64::MAX,
+        1,
+        -127,
+        2,
+        0,
+        0,
+        [0; 4],
+        0,
+        0,
+    );
 
     assert_eq!(u32::MAX, result3.sec());
     assert_eq!(0, result3.sec_fraction());


### PR DESCRIPTION
- Add root_delay, root_dispersion, reference_id, reference_timestamp, poll to NtpResult
- reference_id exposed in network byte order per RFC 5905